### PR TITLE
Nullability, Grid-Compositor Integration, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ class ctlInputMethod: IMKInputController {
 ```swift
   /// 組字器。
   /// - Parameters:
-  ///   - lm: 語言模型。可以是任何基於 Megrez.LanguageModel 的衍生型別。
+  ///   - lm: 語言模型。可以是任何基於 Megrez.LangModel 的衍生型別。
   ///   - length: 指定該組字器內可以允許的最大詞長，預設為 10 字。
   ///   - separator: 多字讀音鍵當中用以分割漢字讀音的記號，預設為空。
   let compositor: Megrez.Compositor = .init(lm: lmTest, length: 13, separator: "-")
@@ -52,10 +52,10 @@ class ctlInputMethod: IMKInputController {
 
 #### // 1. 準備用作語言模型的專用型別
 
-首先，Megrez 內建的 LanguageModel 型別是遠遠不夠用的，只能說是個類似於 protocol 一樣的存在。你需要自己單獨寫一個新的衍生型別：
+首先，Megrez 內建的 LangModel 型別是遠遠不夠用的，只能說是個類似於 protocol 一樣的存在。你需要自己單獨寫一個新的衍生型別：
 
 ```swift
-class ExampleLM: Megrez.LanguageModel {
+class ExampleLM: Megrez.LangModel {
 ...
   override func unigramsFor(key: String) -> [Megrez.Unigram] {
     ...
@@ -88,12 +88,7 @@ MegrezTests.swift 檔案內的 SimpleLM 可以作為範例。
 
 ```swift
   /// 對已給定的軌格按照給定的位置與條件進行正向爬軌。
-  /// - Parameters:
-  ///   - at: 開始爬軌的位置。
-  ///   - score: 給定累計權重，非必填參數。預設值為 0。
-  ///   - joinedPhrase: 用以統計累計長詞的內部參數，請勿主動使用。
-  ///   - longPhrases: 用以統計累計長詞的內部參數，請勿主動使用。
-  var walked = compositor.walk(at: 0, score: 0.0)
+  var walked = compositor.walk()
 ```
 
 MegrezTests.swift 是輸入了很多內容之後再 walk 的。實際上一款輸入法會在你每次插入讀音或刪除讀音的時候都重新 walk。那些處於候選字詞鎖定狀態的節點不會再受到之後的 walk 的行為的影響，但除此之外的節點會因為每次 walk 而可能各自的候選字詞會出現自動變化。如果給了 nodesLimit 一個非零的數值的話，則 walk 的範圍外的節點不會受到影響。
@@ -101,11 +96,15 @@ MegrezTests.swift 是輸入了很多內容之後再 walk 的。實際上一款�
 walk 之後的取值的方法及利用方法可以有很多種。這裡有其中的一個：
 
 ```swift
-    var composed: [String] = []
+    var composed: [String] = walked.map(\.node.currentPair.value)
+    print(composed)
+```
+
+類似於：
+
+```swift
     for phrase in walked {
-      if let node = phrase.node {
-        composed.append(node.currentKeyValue.value)
-      }
+        composed.append(phrase.node.currentKeyValue.value)
     }
     print(composed)
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Megrez Engine is a module made for processing lingual data of an input method. T
 
 以 KeyHandler 為例：
 ```swift
-class KeyHandler: NSObject {
+class KeyHandler {
   // 先設定好變數
   let compositor: Megrez.Compositor = .init()
   ...
@@ -79,10 +79,10 @@ MegrezTests.swift 檔案內的 SimpleLM 可以作為範例。
 這裡只講幾個常用函式：
 
 - 游標位置 `compositor.cursorIndex` 是可以賦值與取值的動態變數，且會在賦值內容為超出位置範圍的數值時自動修正。初期值為 0。
-- `compositor.insertReadingAtCursor(reading: "gao1")` 可以在當前的游標位置插入讀音「gao1」。
-- `compositor.deleteReadingToTheFrontOfCursor()` 的作用是：朝著往文字輸入方向、砍掉一個與游標相鄰的讀音。反之，`deleteReadingAtTheRearOfCursor` 則朝著與文字輸入方向相反的方向、砍掉一個與游標相鄰的讀音。
+- `compositor.insertReading("gao1")` 可以在當前的游標位置插入讀音「gao1」。
+- `compositor.dropReading(direction: .front)` 的作用是：朝著往文字輸入方向、砍掉一個與游標相鄰的讀音。反之，`dropReading(direction: .rear)` 則朝著與文字輸入方向相反的方向、砍掉一個與游標相鄰的讀音。
   - 在威注音的術語體系當中，「文字輸入方向」為向前（Front）、與此相反的方向為向後（Rear）。
-- `compositor.grid.fixNodeSelectedCandidate(location: ?, value: "??")` 用來根據輸入法選中的候選字詞、據此更新當前游標位置選中的候選字詞節點當中的候選字詞。
+- `compositor.grid.fixNodeSelectedCandidate("??", at: ?)` 用來根據輸入法選中的候選字詞、據此更新當前游標位置選中的候選字詞節點當中的候選字詞。
 
 輸入完內容之後，可以聲明一個用來接收結果的變數：
 

--- a/Sources/Megrez/2_Grid.swift
+++ b/Sources/Megrez/2_Grid.swift
@@ -24,7 +24,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
 extension Megrez {
-  /// 軌格。
+  /// 軌格，會被組字器作為原始型別來繼承。
   public class Grid {
     /// 幅位陣列。
     private var spans: [Megrez.SpanUnit]

--- a/Sources/Megrez/2_Grid.swift
+++ b/Sources/Megrez/2_Grid.swift
@@ -27,61 +27,58 @@ extension Megrez {
   /// 軌格。
   public class Grid {
     /// 幅位陣列。
-    private var mutSpans: [Megrez.Span]
+    private var spans: [Megrez.SpanUnit]
 
-    /// 該幅位內可以允許的最大詞長。
-    private var mutMaxBuildSpanLength = 10
-
-    /// 公開：該軌格內可以允許的最大幅位長度。
-    public var maxBuildSpanLength: Int { mutMaxBuildSpanLength }
+    /// 該軌格內可以允許的最大幅位長度。
+    private(set) var maxBuildSpanLength = 10
 
     /// 公開：軌格的寬度，也就是其內的幅位陣列當中的幅位數量。
-    public var width: Int { mutSpans.count }
+    public var width: Int { spans.count }
 
     /// 公開：軌格是否為空。
-    public var isEmpty: Bool { mutSpans.isEmpty }
+    public var isEmpty: Bool { spans.isEmpty }
 
     /// 初期化轨格。
     public init(spanLength: Int = 10) {
-      mutMaxBuildSpanLength = spanLength
-      mutSpans = [Megrez.Span]()
+      maxBuildSpanLength = spanLength
+      spans = [Megrez.SpanUnit]()
     }
 
     /// 自我清空該軌格的內容。
     public func clear() {
-      mutSpans.removeAll()
+      spans.removeAll()
     }
 
     /// 往該軌格的指定位置插入指定幅位長度的指定節點。
     /// - Parameters:
     ///   - node: 節點。
     ///   - location: 位置。
-    ///   - spanningLength: 給定的幅位長度。
-    public func insertNode(node: Node, location: Int, spanningLength: Int) {
+    ///   - spanLength: 給定的幅位長度。
+    public func insertNode(node: Node, location: Int, spanLength: Int) {
       let location = abs(location)  // 防呆
-      let spanningLength = abs(spanningLength)  // 防呆
-      if location >= mutSpans.count {
-        let diff = location - mutSpans.count + 1
+      let spanLength = abs(spanLength)  // 防呆
+      if location >= spans.count {
+        let diff = location - spans.count + 1
         for _ in 0..<diff {
-          mutSpans.append(Span())
+          spans.append(SpanUnit())
         }
       }
-      mutSpans[location].insert(node: node, length: spanningLength)
+      spans[location].insert(node: node, length: spanLength)
     }
 
     /// 給定索引鍵、位置、幅位長度，在該軌格內確認是否有對應的節點存在。
     /// - Parameters:
     ///   - location: 位置。
-    ///   - spanningLength: 給定的幅位長度。
+    ///   - spanLength: 給定的幅位長度。
     ///   - key: 索引鍵。
-    public func hasMatchedNode(location: Int, spanningLength: Int, key: String) -> Bool {
+    public func hasMatchedNode(location: Int, spanLength: Int, key: String) -> Bool {
       let location = abs(location)  // 防呆
-      let spanningLength = abs(spanningLength)  // 防呆
-      if location > mutSpans.count {
+      let spanLength = abs(spanLength)  // 防呆
+      if location > spans.count {
         return false
       }
 
-      let n = mutSpans[location].node(length: spanningLength)
+      let n = spans[location].nodeOf(length: spanLength)
       return n != nil && key == n?.key
     }
 
@@ -90,11 +87,11 @@ extension Megrez {
     ///   - location: 位置。
     public func expandGridByOneAt(location: Int) {
       let location = abs(location)  // 防呆
-      mutSpans.insert(Span(), at: location)
-      if location == 0 || location == mutSpans.count { return }
+      spans.insert(SpanUnit(), at: location)
+      if location == 0 || location == spans.count { return }
       for i in 0..<location {
         // zaps overlapping spans
-        mutSpans[i].removeNodeOfLengthGreaterThan(location - i)
+        spans[i].removeNodeOfLengthBeyond(location - i)
       }
     }
 
@@ -103,14 +100,14 @@ extension Megrez {
     ///   - location: 位置。
     public func shrinkGridByOneAt(location: Int) {
       let location = abs(location)  // 防呆
-      if location >= mutSpans.count {
+      if location >= spans.count {
         return
       }
 
-      mutSpans.remove(at: location)
+      spans.remove(at: location)
       for i in 0..<location {
         // zaps overlapping spans
-        mutSpans[i].removeNodeOfLengthGreaterThan(location - i)
+        spans[i].removeNodeOfLengthBeyond(location - i)
       }
     }
 
@@ -120,21 +117,21 @@ extension Megrez {
     public func nodesBeginningAt(location: Int) -> [NodeAnchor] {
       let location = abs(location)  // 防呆
       var results = [NodeAnchor]()
-      if location >= mutSpans.count { return results }
-      // 此時 mutSpans 必然不為空，因為 location 不可能小於 0。
-      let span = mutSpans[location]
+      if location >= spans.count { return results }
+      // 此時 spans 必然不為空，因為 location 不可能小於 0。
+      let span = spans[location]
       for i in 1...maxBuildSpanLength {
-        if let np = span.node(length: i) {
+        if let np = span.nodeOf(length: i) {
           results.append(
             .init(
               node: np,
               location: location,
-              spanningLength: i
+              spanLength: i
             )
           )
         }
       }
-      return results
+      return results  // 已證實不會有空節點產生。
     }
 
     /// 給定位置，枚舉出所有在這個位置結尾的節點。
@@ -143,21 +140,21 @@ extension Megrez {
     public func nodesEndingAt(location: Int) -> [NodeAnchor] {
       let location = abs(location)  // 防呆
       var results = [NodeAnchor]()
-      if mutSpans.isEmpty || location > mutSpans.count { return results }
+      if spans.isEmpty || location > spans.count { return results }
       for i in 0..<location {
-        let span = mutSpans[i]
-        if i + span.maximumLength < location { continue }
-        if let np = span.node(length: location - i) {
+        let span = spans[i]
+        if i + span.maxLength < location { continue }
+        if let np = span.nodeOf(length: location - i) {
           results.append(
             .init(
               node: np,
               location: i,
-              spanningLength: location - i
+              spanLength: location - i
             )
           )
         }
       }
-      return results
+      return results  // 已證實不會有空節點產生。
     }
 
     /// 給定位置，枚舉出所有在這個位置結尾、或者橫跨該位置的節點。
@@ -166,24 +163,24 @@ extension Megrez {
     public func nodesCrossingOrEndingAt(location: Int) -> [NodeAnchor] {
       let location = abs(location)  // 防呆
       var results = [NodeAnchor]()
-      if mutSpans.isEmpty || location > mutSpans.count { return results }
+      if spans.isEmpty || location > spans.count { return results }
       for i in 0..<location {
-        let span = mutSpans[i]
-        if i + span.maximumLength < location { continue }
-        for j in 1...span.maximumLength {
+        let span = spans[i]
+        if i + span.maxLength < location { continue }
+        for j in 1...span.maxLength {
           if i + j < location { continue }
-          if let np = span.node(length: j) {
+          if let np = span.nodeOf(length: j) {
             results.append(
               .init(
                 node: np,
                 location: i,
-                spanningLength: location - i
+                spanLength: location - i
               )
             )
           }
         }
       }
-      return results
+      return results  // 已證實不會有空節點產生。
     }
 
     /// 將給定位置的節點的候選字詞改為與給定的字串一致的候選字詞。
@@ -195,17 +192,16 @@ extension Megrez {
     @discardableResult public func fixNodeSelectedCandidate(location: Int, value: String) -> NodeAnchor {
       let location = abs(location)  // 防呆
       var node = NodeAnchor()
-      for nodeAnchor in nodesCrossingOrEndingAt(location: location) {
-        guard let theNode = nodeAnchor.node else {
-          continue
-        }
-        let candidates = theNode.candidates
+      for theAnchor
+        in nodesCrossingOrEndingAt(location: location)
+      {
+        let candidates = theAnchor.node.candidates
         // 將該位置的所有節點的候選字詞鎖定狀態全部重設。
-        theNode.resetCandidate()
+        theAnchor.node.resetCandidate()
         for (i, candidate) in candidates.enumerated() {
           if candidate.value == value {
-            theNode.selectCandidateAt(index: i)
-            node = nodeAnchor
+            theAnchor.node.selectCandidateAt(index: i)
+            node = theAnchor
             break
           }
         }
@@ -220,16 +216,15 @@ extension Megrez {
     ///   - overridingScore: 給定權重數值。
     public func overrideNodeScoreForSelectedCandidate(location: Int, value: String, overridingScore: Double) {
       let location = abs(location)  // 防呆
-      for nodeAnchor in nodesCrossingOrEndingAt(location: location) {
-        guard let theNode = nodeAnchor.node else {
-          continue
-        }
-        let candidates = theNode.candidates
+      for theAnchor
+        in nodesCrossingOrEndingAt(location: location)
+      {
+        let candidates = theAnchor.node.candidates
         // 將該位置的所有節點的候選字詞鎖定狀態全部重設。
-        theNode.resetCandidate()
+        theAnchor.node.resetCandidate()
         for (i, candidate) in candidates.enumerated() {
           if candidate.value == value {
-            theNode.selectFloatingCandidateAt(index: i, score: overridingScore)
+            theAnchor.node.selectFloatingCandidateAt(index: i, score: overridingScore)
             break
           }
         }
@@ -244,29 +239,22 @@ extension Megrez.Grid {
   /// 生成用以交給 GraphViz 診斷的資料檔案內容，純文字。
   public var dumpDOT: String {
     var strOutput = "digraph {\ngraph [ rankdir=LR ];\nBOS;\n"
-    for (p, span) in mutSpans.enumerated() {
-      for ni in 0...(span.maximumLength) {
-        guard let np: Megrez.Node = span.node(length: ni) else {
-          continue
-        }
+    for (p, span) in spans.enumerated() {
+      for ni in 0...(span.maxLength) {
+        guard let np = span.nodeOf(length: ni) else { continue }
         if p == 0 {
-          strOutput += "BOS -> \(np.currentKeyValue.value);\n"
+          strOutput += "BOS -> \(np.currentPair.value);\n"
         }
-
-        strOutput += "\(np.currentKeyValue.value);\n"
-
-        if (p + ni) < mutSpans.count {
-          let destinationSpan = mutSpans[p + ni]
-          for q in 0...(destinationSpan.maximumLength) {
-            if let dn = destinationSpan.node(length: q) {
-              strOutput += np.currentKeyValue.value + " -> " + dn.currentKeyValue.value + ";\n"
-            }
+        strOutput += "\(np.currentPair.value);\n"
+        if (p + ni) < spans.count {
+          let destinationSpan = spans[p + ni]
+          for q in 0...(destinationSpan.maxLength) {
+            guard let dn = destinationSpan.nodeOf(length: q) else { continue }
+            strOutput += np.currentPair.value + " -> " + dn.currentPair.value + ";\n"
           }
         }
-
-        if (p + ni) == mutSpans.count {
-          strOutput += np.currentKeyValue.value + " -> EOS;\n"
-        }
+        guard (p + ni) == spans.count else { continue }
+        strOutput += np.currentPair.value + " -> EOS;\n"
       }
     }
     strOutput += "EOS;\n}\n"

--- a/Sources/Megrez/3_NodeAnchor.swift
+++ b/Sources/Megrez/3_NodeAnchor.swift
@@ -25,7 +25,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 extension Megrez {
   /// 節锚。
-  @frozen public struct NodeAnchor {
+  @frozen public struct NodeAnchor: Hashable {
     /// 用來判斷該節錨是否為空。
     public var isEmpty: Bool { node.key.isEmpty }
     /// 節點。一個節锚內不一定有節點。
@@ -39,6 +39,13 @@ extension Megrez {
     /// 索引鍵的長度。
     public var keyLength: Int {
       isEmpty ? node.key.count : 0
+    }
+
+    public func hash(into hasher: inout Hasher) {
+      hasher.combine(node)
+      hasher.combine(location)
+      hasher.combine(spanLength)
+      hasher.combine(mass)
     }
 
     /// 將當前節锚列印成一個字串。
@@ -61,7 +68,7 @@ extension Megrez {
   }
 }
 
-// MARK: - DumpDOT-related functions.
+// MARK: - Array Extensions.
 
 extension Array where Element == Megrez.NodeAnchor {
   /// 將節锚陣列列印成一個字串。
@@ -71,5 +78,15 @@ extension Array where Element == Megrez.NodeAnchor {
       arrOutputContent.append(anchor.description)
     }
     return arrOutputContent.joined(separator: "<-")
+  }
+
+  /// 從一個節錨陣列當中取出目前的自動選字字串陣列。
+  public var values: [String] {
+    map(\.node.currentPair.value)
+  }
+
+  /// 從一個節錨陣列當中取出目前的索引鍵陣列。
+  public var keys: [String] {
+    map(\.node.currentPair.key)
   }
 }

--- a/Sources/Megrez/3_NodeAnchor.swift
+++ b/Sources/Megrez/3_NodeAnchor.swift
@@ -25,25 +25,27 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 extension Megrez {
   /// 節锚。
-  @frozen public struct NodeAnchor: CustomStringConvertible {
+  @frozen public struct NodeAnchor {
+    /// 用來判斷該節錨是否為空。
+    public var isEmpty: Bool { node.key.isEmpty }
     /// 節點。一個節锚內不一定有節點。
-    public var node: Node?
+    public var node: Node = .init()
     /// 節锚所在的位置。
     public var location: Int = 0
-    /// 幅位長度。
-    public var spanningLength: Int = 0
+    /// 指定的幅位長度。
+    public var spanLength: Int = 0
     /// 累計權重。
-    public var accumulatedScore: Double = 0.0
+    public var mass: Double = 0.0
     /// 索引鍵的長度。
     public var keyLength: Int {
-      node?.key.count ?? 0
+      isEmpty ? node.key.count : 0
     }
 
     /// 將當前節锚列印成一個字串。
     public var description: String {
       var stream = ""
-      stream += "{@(" + String(location) + "," + String(spanningLength) + "),"
-      if let node = node {
+      stream += "{@(" + String(location) + "," + String(spanLength) + "),"
+      if node.key.isEmpty {
         stream += node.description
       } else {
         stream += "null"
@@ -54,7 +56,7 @@ extension Megrez {
 
     /// 獲取用來比較的權重。
     public var scoreForSort: Double {
-      node?.score ?? 0
+      isEmpty ? node.score : 0
     }
   }
 }

--- a/Sources/Megrez/3_Span.swift
+++ b/Sources/Megrez/3_Span.swift
@@ -50,7 +50,7 @@ extension Megrez {
     /// 移除任何比給定的長度更長的節點。
     /// - Parameters:
     ///   - length: 給定的節點長度。
-    mutating func removeNodeOfLengthBeyond(_ length: Int) {
+    mutating func dropNodesBeyond(length: Int) {
       let length = abs(length)  // 防呆
       if length > maxLength { return }
       var lenMax = 0

--- a/Sources/Megrez/3_Span.swift
+++ b/Sources/Megrez/3_Span.swift
@@ -25,21 +25,16 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 extension Megrez {
   /// 幅位。
-  @frozen public struct Span {
+  @frozen public struct SpanUnit {
     /// 辭典：以節點長度為索引，以節點為資料值。
-    private var mutLengthNodeMap: [Int: Megrez.Node] = [:]
-    /// 最大節點長度。
-    private var mutMaximumLength: Int = 0
-
-    /// 公開：最長幅距（唯讀）。
-    public var maximumLength: Int {
-      mutMaximumLength
-    }
+    private var lengthNodeMap: [Int: Megrez.Node] = [:]
+    /// 最長幅距。
+    private(set) var maxLength: Int = 0
 
     /// 自我清空，各項參數歸零。
     mutating func clear() {
-      mutLengthNodeMap.removeAll()
-      mutMaximumLength = 0
+      lengthNodeMap.removeAll()
+      maxLength = 0
     }
 
     /// 往自身插入一個節點、及給定的節點長度。
@@ -48,37 +43,37 @@ extension Megrez {
     ///   - length: 給定的節點長度。
     mutating func insert(node: Node, length: Int) {
       let length = abs(length)  // 防呆
-      mutLengthNodeMap[length] = node
-      mutMaximumLength = max(mutMaximumLength, length)
+      lengthNodeMap[length] = node
+      maxLength = max(maxLength, length)
     }
 
     /// 移除任何比給定的長度更長的節點。
     /// - Parameters:
     ///   - length: 給定的節點長度。
-    mutating func removeNodeOfLengthGreaterThan(_ length: Int) {
+    mutating func removeNodeOfLengthBeyond(_ length: Int) {
       let length = abs(length)  // 防呆
-      if length > mutMaximumLength { return }
+      if length > maxLength { return }
       var lenMax = 0
       var removalList: [Int: Megrez.Node] = [:]
-      for key in mutLengthNodeMap.keys {
+      for key in lengthNodeMap.keys {
         if key > length {
-          removalList[key] = mutLengthNodeMap[key]
+          removalList[key] = lengthNodeMap[key]
         } else {
           lenMax = max(lenMax, key)
         }
       }
       for key in removalList.keys {
-        mutLengthNodeMap.removeValue(forKey: key)
+        lengthNodeMap.removeValue(forKey: key)
       }
-      mutMaximumLength = lenMax
+      maxLength = lenMax
     }
 
     /// 給定節點長度，獲取節點。
     /// - Parameters:
     ///   - length: 給定的節點長度。
-    public func node(length: Int) -> Node? {
+    public func nodeOf(length: Int) -> Node? {
       // 防呆 Abs()
-      mutLengthNodeMap.keys.contains(abs(length)) ? mutLengthNodeMap[abs(length)] : nil
+      lengthNodeMap.keys.contains(abs(length)) ? lengthNodeMap[abs(length)] : nil
     }
   }
 }

--- a/Sources/Megrez/4_Node.swift
+++ b/Sources/Megrez/4_Node.swift
@@ -25,7 +25,26 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 extension Megrez {
   /// 節點。
-  public class Node {
+  public class Node: Equatable, Hashable {
+    public static func == (lhs: Megrez.Node, rhs: Megrez.Node) -> Bool {
+      lhs.key == rhs.key && lhs.score == rhs.score && lhs.unigrams == rhs.unigrams && lhs.bigrams == rhs.bigrams
+        && lhs.candidates == rhs.candidates && lhs.valueUnigramIndexMap == rhs.valueUnigramIndexMap
+        && lhs.precedingBigramMap == rhs.precedingBigramMap && lhs.isCandidateFixed == rhs.isCandidateFixed
+        && lhs.selectedUnigramIndex == rhs.selectedUnigramIndex
+    }
+
+    public func hash(into hasher: inout Hasher) {
+      hasher.combine(key)
+      hasher.combine(score)
+      hasher.combine(unigrams)
+      hasher.combine(bigrams)
+      hasher.combine(candidates)
+      hasher.combine(valueUnigramIndexMap)
+      hasher.combine(precedingBigramMap)
+      hasher.combine(isCandidateFixed)
+      hasher.combine(selectedUnigramIndex)
+    }
+
     /// 鍵。
     private(set) var key: String = ""
     /// 當前節點的當前被選中的候選字詞「在該節點內的」目前的權重。

--- a/Sources/Megrez/4_Node.swift
+++ b/Sources/Megrez/4_Node.swift
@@ -126,7 +126,7 @@ extension Megrez {
     public func resetCandidate() {
       selectedUnigramIndex = 0
       isCandidateFixed = false
-      if !self.unigrams.isEmpty {
+      if !unigrams.isEmpty {
         score = unigrams[0].score
       }
     }

--- a/Sources/Megrez/4_Node.swift
+++ b/Sources/Megrez/4_Node.swift
@@ -27,74 +27,65 @@ extension Megrez {
   /// 節點。
   public class Node {
     /// 鍵。
-    private var mutKey: String = ""
+    private(set) var key: String = ""
     /// 當前節點的當前被選中的候選字詞「在該節點內的」目前的權重。
-    private var mutScore: Double = 0
+    private(set) var score: Double = 0
     /// 單元圖陣列。
-    private var mutUnigrams: [Unigram]
+    private var unigrams: [Unigram]
     /// 雙元圖陣列。
-    private var mutBigrams: [Bigram]
+    private var bigrams: [Bigram]
     /// 候選字詞陣列，以鍵值陣列的形式存在。
-    private var mutCandidates: [KeyValuePaired] = []
+    private(set) var candidates: [KeyValuePaired] = []
     /// 專門「用單元圖資料值來調查索引值」的辭典。
-    private var mutValueUnigramIndexMap: [String: Int] = [:]
+    private var valueUnigramIndexMap: [String: Int] = [:]
     /// 專門「用給定鍵值來取對應的雙元圖陣列」的辭典。
-    private var mutPrecedingBigramMap: [KeyValuePaired: [Megrez.Bigram]] = [:]
+    private var precedingBigramMap: [KeyValuePaired: [Megrez.Bigram]] = [:]
     /// 狀態標記變數，用來記載當前節點是否處於候選字詞鎖定狀態。
-    private var mutCandidateFixed: Bool = false
+    private(set) var isCandidateFixed: Bool = false
     /// 用來登記「當前選中的單元圖」的索引值的變數。
-    private var mutSelectedUnigramIndex: Int = 0
+    private var selectedUnigramIndex: Int = 0
     /// 用來登記要施加給「『被標記為選中狀態』的候選字詞」的複寫權重的數值。
-    public let kSelectedCandidateScore: Double = 99
+    public static let kSelectedCandidateScore: Double = 99
     /// 將當前節點列印成一個字串。
     public var description: String {
-      "(node,key:\(mutKey),fixed:\(mutCandidateFixed ? "true" : "false"),selected:\(mutSelectedUnigramIndex),\(mutUnigrams))"
+      "(node,key:\(key),fixed:\(isCandidateFixed ? "true" : "false"),selected:\(selectedUnigramIndex),\(unigrams))"
     }
 
-    /// 公開：候選字詞陣列（唯讀），以鍵值陣列的形式存在。
-    public var candidates: [KeyValuePaired] { mutCandidates }
-    /// 公開：用來登記「當前選中的單元圖」的索引值的變數（唯讀）。
-    public var isCandidateFixed: Bool { mutCandidateFixed }
-
-    /// 公開：鍵（唯讀）。
-    public var key: String { mutKey }
-    /// 公開：當前節點的當前被選中的候選字詞「在該節點內的」目前的權重（唯讀）。
-    public var score: Double { mutScore }
     /// 公開：當前被選中的候選字詞的鍵值配對。
-    public var currentKeyValue: KeyValuePaired {
-      mutSelectedUnigramIndex >= mutUnigrams.count ? KeyValuePaired() : mutCandidates[mutSelectedUnigramIndex]
+    public var currentPair: KeyValuePaired {
+      selectedUnigramIndex >= unigrams.count ? KeyValuePaired() : candidates[selectedUnigramIndex]
     }
 
     /// 公開：給出當前單元圖陣列內最高的權重數值。
-    public var highestUnigramScore: Double { mutUnigrams.isEmpty ? 0.0 : mutUnigrams[0].score }
+    public var highestUnigramScore: Double { unigrams.isEmpty ? 0.0 : unigrams[0].score }
 
     /// 初期化一個節點。
     /// - Parameters:
     ///   - key: 索引鍵。
     ///   - unigrams: 單元圖陣列。
     ///   - bigrams: 雙元圖陣列（非必填）。
-    public init(key: String, unigrams: [Megrez.Unigram], bigrams: [Megrez.Bigram] = []) {
-      mutKey = key
-      mutUnigrams = unigrams
-      mutBigrams = bigrams
+    public init(key: String = "", unigrams: [Megrez.Unigram] = [], bigrams: [Megrez.Bigram] = []) {
+      self.key = key
+      self.unigrams = unigrams
+      self.bigrams = bigrams
 
-      mutUnigrams.sort {
+      self.unigrams.sort {
         $0.score > $1.score
       }
 
-      if !mutUnigrams.isEmpty {
-        mutScore = mutUnigrams[0].score
+      if !self.unigrams.isEmpty {
+        score = unigrams[0].score
       }
 
-      for (i, gram) in mutUnigrams.enumerated() {
-        mutValueUnigramIndexMap[gram.keyValue.value] = i
-        mutCandidates.append(gram.keyValue)
+      for (i, gram) in self.unigrams.enumerated() {
+        valueUnigramIndexMap[gram.keyValue.value] = i
+        candidates.append(gram.keyValue)
       }
 
       for gram in bigrams.lazy.filter({ [self] in
-        mutPrecedingBigramMap.keys.contains($0.precedingKeyValue)
+        precedingBigramMap.keys.contains($0.precedingKeyValue)
       }) {
-        mutPrecedingBigramMap[gram.precedingKeyValue]?.append(gram)
+        precedingBigramMap[gram.precedingKeyValue]?.append(gram)
       }
     }
 
@@ -102,22 +93,22 @@ extension Megrez {
     /// - Parameters:
     ///   - precedingKeyValues: 前述鍵值陣列。
     public func primeNodeWith(precedingKeyValues: [KeyValuePaired]) {
-      var newIndex = mutSelectedUnigramIndex
-      var max = mutScore
+      var newIndex = selectedUnigramIndex
+      var max = score
 
       if !isCandidateFixed {
         for neta in precedingKeyValues {
-          let bigrams = mutPrecedingBigramMap[neta] ?? []
+          let bigrams = precedingBigramMap[neta] ?? []
           for bigram in bigrams.lazy.filter({ [self] in
-            $0.score > max && mutValueUnigramIndexMap.keys.contains($0.keyValue.value)
+            $0.score > max && valueUnigramIndexMap.keys.contains($0.keyValue.value)
           }) {
-            newIndex = mutValueUnigramIndexMap[bigram.keyValue.value] ?? newIndex
+            newIndex = valueUnigramIndexMap[bigram.keyValue.value] ?? newIndex
             max = bigram.score
           }
         }
       }
-      mutScore = max
-      mutSelectedUnigramIndex = newIndex
+      score = max
+      selectedUnigramIndex = newIndex
     }
 
     /// 選中位於給定索引位置的候選字詞。
@@ -126,17 +117,17 @@ extension Megrez {
     ///   - fix: 是否將當前解點標記為「候選詞已鎖定」的狀態。
     public func selectCandidateAt(index: Int = 0, fix: Bool = false) {
       let index = abs(index)
-      mutSelectedUnigramIndex = index >= mutUnigrams.count ? 0 : index
-      mutCandidateFixed = fix
-      mutScore = kSelectedCandidateScore
+      selectedUnigramIndex = index >= unigrams.count ? 0 : index
+      isCandidateFixed = fix
+      score = Megrez.Node.kSelectedCandidateScore
     }
 
     /// 重設該節點的候選字詞狀態。
     public func resetCandidate() {
-      mutSelectedUnigramIndex = 0
-      mutCandidateFixed = false
-      if !mutUnigrams.isEmpty {
-        mutScore = mutUnigrams[0].score
+      selectedUnigramIndex = 0
+      isCandidateFixed = false
+      if !self.unigrams.isEmpty {
+        score = unigrams[0].score
       }
     }
 
@@ -146,16 +137,16 @@ extension Megrez {
     ///   - score: 給定權重條件。
     public func selectFloatingCandidateAt(index: Int, score: Double) {
       let index = abs(index)  // 防呆
-      mutSelectedUnigramIndex = index >= mutUnigrams.count ? 0 : index
-      mutCandidateFixed = false
-      mutScore = score
+      selectedUnigramIndex = index >= unigrams.count ? 0 : index
+      isCandidateFixed = false
+      self.score = score
     }
 
     /// 藉由給定的候選字詞字串，找出在庫的單元圖權重數值。沒有的話就找零。
     /// - Parameters:
     ///   - candidate: 給定的候選字詞字串。
     public func scoreFor(candidate: String) -> Double {
-      for unigram in mutUnigrams.lazy.filter({ $0.keyValue.value == candidate }) {
+      for unigram in unigrams.lazy.filter({ $0.keyValue.value == candidate }) {
         return unigram.score
       }
       return 0.0

--- a/Sources/Megrez/5_LanguageModel.swift
+++ b/Sources/Megrez/5_LanguageModel.swift
@@ -23,7 +23,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-public protocol LanguageModelProtocol {
+public protocol LangModelProtocol {
   /// 給定鍵，讓語言模型找給一組單元圖陣列。
   func unigramsFor(key: String) -> [Megrez.Unigram]
 
@@ -36,7 +36,7 @@ public protocol LanguageModelProtocol {
 
 extension Megrez {
   /// 語言模型框架，回頭實際使用時需要派生一個型別、且重寫相關函式。
-  open class LanguageModel: LanguageModelProtocol {
+  open class LangModel: LangModelProtocol {
     public init() {}
 
     // 這裡寫了一點假內容，不然有些 Swift 格式化工具會破壞掉函式的參數設計。

--- a/Sources/Megrez/6_Bigram.swift
+++ b/Sources/Megrez/6_Bigram.swift
@@ -25,7 +25,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 extension Megrez {
   /// 雙元圖。
-  @frozen public struct Bigram: Equatable, CustomStringConvertible {
+  @frozen public struct Bigram: Equatable, CustomStringConvertible, Hashable {
     /// 當前鍵值。
     public var keyValue: KeyValuePaired
     /// 前述鍵值。

--- a/Sources/Megrez/6_Unigram.swift
+++ b/Sources/Megrez/6_Unigram.swift
@@ -25,7 +25,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 extension Megrez {
   /// 單元圖。
-  @frozen public struct Unigram: Equatable, CustomStringConvertible {
+  @frozen public struct Unigram: Equatable, CustomStringConvertible, Hashable {
     /// 鍵值。
     public var keyValue: KeyValuePaired
     /// 權重。

--- a/Tests/MegrezTests/LMDataForTests.swift
+++ b/Tests/MegrezTests/LMDataForTests.swift
@@ -1,0 +1,196 @@
+// Swiftified by (c) 2022 and onwards The vChewing Project (MIT-NTL License).
+// Rebranded from (c) Lukhnos Liu's C++ library "Gramambular" (MIT License).
+/*
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+1. The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+2. No trademark license is granted to use the trade names, trademarks, service
+marks, or product names of Contributor, except as required to fulfill notice
+requirements above.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+import Megrez
+
+// MARK: - 用以測試的語言模型（簡單範本型）
+
+class SimpleLM: LangModelProtocol {
+  func bigramsForKeys(precedingKey _: String, key _: String) -> [Megrez.Bigram] {
+    .init()
+  }
+
+  var mutDatabase: [String: [Megrez.Unigram]] = [:]
+  init(input: String, swapKeyValue: Bool = false) {
+    let sstream = input.components(separatedBy: "\n")
+    for line in sstream {
+      if line.isEmpty || line.hasPrefix("#") {
+        continue
+      }
+      let linestream = line.split(separator: " ")
+      let col0 = String(linestream[0])
+      let col1 = String(linestream[1])
+      let col2 = Double(linestream[2]) ?? 0.0
+      var u = Megrez.Unigram(
+        keyValue: .init(key: swapKeyValue ? col1 : col0, value: swapKeyValue ? col0 : col1), score: 0
+      )
+      u.score = col2
+      mutDatabase[swapKeyValue ? col1 : col0, default: []].append(u)
+    }
+  }
+
+  func unigramsFor(key: String) -> [Megrez.Unigram] {
+    if let f = mutDatabase[key] {
+      return f
+    } else {
+      return [Megrez.Unigram]().sorted { $0.score > $1.score }
+    }
+  }
+
+  func hasUnigramsFor(key: String) -> Bool {
+    mutDatabase.keys.contains(key)
+  }
+}
+
+class MockLM: LangModelProtocol {
+  func bigramsForKeys(precedingKey _: String, key _: String) -> [Megrez.Bigram] {
+    .init()
+  }
+
+  func unigramsFor(key: String) -> [Megrez.Unigram] {
+    [.init(keyValue: .init(key: key, value: key), score: -1)]
+  }
+
+  func hasUnigramsFor(key: String) -> Bool {
+    !key.isEmpty
+  }
+}
+
+// MARK: - 用以測試的詞頻數據
+
+public let strStressData = #"""
+yi1 一 -2.08170692
+yi1-yi1 一一 -4.38468400
+
+"""#
+
+public let strEmojiSampleData = #"""
+gao1 高 -2.9396
+re4 熱 -3.6024
+gao1re4 高熱 -6.526
+huo3 火 -3.6966
+huo3 🔥 -8
+yan4 焰 -5.4466
+huo3yan4 火焰 -5.6231
+huo3yan4 🔥 -8
+wei2 危 -3.9832
+xian3 險 -3.7810
+wei2xian3 危險 -4.2623
+
+"""#
+
+public let strSampleData = #"""
+#
+# 下述詞頻資料取自 libTaBE 資料庫 (http://sourceforge.net/projects/libtabe/)
+# (2002 最終版). 該專案於 1999 年由 Pai-Hsiang Hsiao 發起、以 BSD 授權發行。
+#
+ni3 你 -6.000000 // Non-LibTaBE
+zhe4 這 -6.000000 // Non-LibTaBE
+yang4 樣 -6.000000 // Non-LibTaBE
+si1 絲 -9.495858
+si1 思 -9.006414
+si1 私 -99.000000
+si1 斯 -8.091803
+si1 司 -99.000000
+si1 嘶 -13.513987
+si1 撕 -12.259095
+gao1 高 -7.171551
+ke1 顆 -10.574273
+ke1 棵 -11.504072
+ke1 刻 -10.450457
+ke1 科 -7.171052
+ke1 柯 -99.000000
+gao1 膏 -11.928720
+gao1 篙 -13.624335
+gao1 糕 -12.390804
+de5 的 -3.516024
+di2 的 -3.516024
+di4 的 -3.516024
+zhong1 中 -5.809297
+de5 得 -7.427179
+gong1 共 -8.381971
+gong1 供 -8.501463
+ji4 既 -99.000000
+jin1 今 -8.034095
+gong1 紅 -8.858181
+ji4 際 -7.608341
+ji4 季 -99.000000
+jin1 金 -7.290109
+ji4 騎 -10.939895
+zhong1 終 -99.000000
+ji4 記 -99.000000
+ji4 寄 -99.000000
+jin1 斤 -99.000000
+ji4 繼 -9.715317
+ji4 計 -7.926683
+ji4 暨 -8.373022
+zhong1 鐘 -9.877580
+jin1 禁 -10.711079
+gong1 公 -7.877973
+gong1 工 -7.822167
+gong1 攻 -99.000000
+gong1 功 -99.000000
+gong1 宮 -99.000000
+zhong1 鍾 -9.685671
+ji4 繫 -10.425662
+gong1 弓 -99.000000
+gong1 恭 -99.000000
+ji4 劑 -8.888722
+ji4 祭 -10.204425
+jin1 浸 -11.378321
+zhong1 盅 -99.000000
+ji4 忌 -99.000000
+ji4 技 -8.450826
+jin1 筋 -11.074890
+gong1 躬 -99.000000
+ji4 冀 -12.045357
+zhong1 忠 -99.000000
+ji4 妓 -99.000000
+ji4 濟 -9.517568
+ji4 薊 -12.021587
+jin1 巾 -99.000000
+jin1 襟 -12.784206
+nian2 年 -6.086515
+jiang3 講 -9.164384
+jiang3 獎 -8.690941
+jiang3 蔣 -10.127828
+nian2 黏 -11.336864
+nian2 粘 -11.285740
+jiang3 槳 -12.492933
+gong1si1 公司 -6.299461
+ke1ji4 科技 -6.736613
+ji4gong1 濟公 -13.336653
+jiang3jin1 獎金 -10.344678
+nian2zhong1 年終 -11.668947
+nian2zhong1 年中 -11.373044
+gao1ke1ji4 高科技 -9.842421
+zhe4yang4 這樣 -6.000000 // Non-LibTaBE
+ni3zhe4 你這 -9.000000 // Non-LibTaBE
+jiao4 教 -3.676169
+jiao4 較 -3.24869962
+jiao4yu4 教育 -3.32220565
+yu4 育 -3.30192952
+
+"""#

--- a/Tests/MegrezTests/MegrezTests.swift
+++ b/Tests/MegrezTests/MegrezTests.swift
@@ -37,7 +37,7 @@ final class MegrezTests: XCTestCase {
     var walked = [Megrez.NodeAnchor]()
 
     func walk() {
-      walked = compositor.walk(at: 0, score: 0.0)
+      walked = compositor.walk()
     }
 
     // 模擬輸入法的行為，每次敲字或選字都重新 walk。
@@ -102,12 +102,7 @@ final class MegrezTests: XCTestCase {
     walk()
     XCTAssert(!walked.isEmpty)
 
-    var composed: [String] = []
-    for phrase in walked {
-      if let node = phrase.node {
-        composed.append(node.currentKeyValue.value)
-      }
-    }
+    var composed: [String] = walked.map(\.node.currentPair.value)
     print(composed)
     let correctResult = ["高科技", "公司", "的", "年終", "獎金", "你", "這樣"]
     print(" - 上述列印結果理應於下面這行一致：")
@@ -134,111 +129,12 @@ final class MegrezTests: XCTestCase {
     compositor.grid.fixNodeSelectedCandidate(location: 2, value: "教育")
     walk()
 
-    composed.removeAll()
-    for phrase in walked {
-      if let node = phrase.node {
-        composed.append(node.currentKeyValue.value)
-      }
-    }
+    composed = walked.map(\.node.currentPair.value)
     print(composed)
     let expectedResult = ["教育"]
     print(" - 上述列印結果理應於下面這行一致：")
     print(expectedResult)
     XCTAssertEqual(composed, expectedResult)
-  }
-
-  func testInputWithreverseWalk() throws {
-    print("// 開始測試語言文字輸入處理")
-    let lmTestInput = SimpleLM(input: strSampleData)
-    let compositor = Megrez.Compositor(lm: lmTestInput)
-    var walked = [Megrez.NodeAnchor]()
-
-    func reverseWalk(at location: Int) {
-      walked = Array(compositor.reverseWalk(at: location, score: 0.0).reversed())
-    }
-
-    // 模擬輸入法的行為，每次敲字或選字都重新 walk。
-    compositor.insertReadingAtCursor(reading: "gao1")
-    reverseWalk(at: compositor.grid.width)
-    compositor.insertReadingAtCursor(reading: "ji4")
-    reverseWalk(at: compositor.grid.width)
-    compositor.cursorIndex = 1
-    compositor.insertReadingAtCursor(reading: "ke1")
-    reverseWalk(at: compositor.grid.width)
-    compositor.cursorIndex = 1
-    compositor.deleteReadingToTheFrontOfCursor()
-    reverseWalk(at: compositor.grid.width)
-    compositor.insertReadingAtCursor(reading: "ke1")
-    reverseWalk(at: compositor.grid.width)
-    compositor.cursorIndex = 0
-    compositor.deleteReadingToTheFrontOfCursor()
-    reverseWalk(at: compositor.grid.width)
-    compositor.insertReadingAtCursor(reading: "gao1")
-    reverseWalk(at: compositor.grid.width)
-    compositor.cursorIndex = compositor.length
-    compositor.insertReadingAtCursor(reading: "gong1")
-    reverseWalk(at: compositor.grid.width)
-    compositor.insertReadingAtCursor(reading: "si1")
-    reverseWalk(at: compositor.grid.width)
-    compositor.insertReadingAtCursor(reading: "de5")
-    reverseWalk(at: compositor.grid.width)
-    compositor.insertReadingAtCursor(reading: "nian2")
-    reverseWalk(at: compositor.grid.width)
-    compositor.insertReadingAtCursor(reading: "zhong1")
-    reverseWalk(at: compositor.grid.width)
-    compositor.grid.fixNodeSelectedCandidate(location: 7, value: "年終")
-    reverseWalk(at: compositor.grid.width)
-    compositor.insertReadingAtCursor(reading: "jiang3")
-    reverseWalk(at: compositor.grid.width)
-    compositor.insertReadingAtCursor(reading: "jin1")
-    reverseWalk(at: compositor.grid.width)
-    compositor.insertReadingAtCursor(reading: "ni3")
-    reverseWalk(at: compositor.grid.width)
-    compositor.insertReadingAtCursor(reading: "zhe4")
-    reverseWalk(at: compositor.grid.width)
-    compositor.insertReadingAtCursor(reading: "yang4")
-    reverseWalk(at: compositor.grid.width)
-
-    // 這裡模擬一個輸入法的常見情況：每次敲一個字詞都會 walk，然後你回頭編輯完一些內容之後又會立刻重新 walk。
-    // 如果只在這裡測試第一遍 walk 的話，測試通過了也無法測試之後再次 walk 是否會正常。
-
-    compositor.cursorIndex = 1
-    compositor.deleteReadingToTheFrontOfCursor()
-
-    // 於是咱們 walk 第二遍
-    reverseWalk(at: compositor.grid.width)
-    XCTAssert(!walked.isEmpty)
-
-    // 做好第三遍的準備，這次咱們來一次插入性編輯。
-    // 重點測試這句是否正常，畢竟是在 walked 過的節點內進行插入編輯。
-    compositor.insertReadingAtCursor(reading: "ke1")
-
-    // 於是咱們 walk 第三遍。
-    // 這一遍會直接曝露「上述修改是否有對 compositor 造成了破壞性的損失」，
-    // 所以很重要。
-    reverseWalk(at: compositor.grid.width)
-    XCTAssert(!walked.isEmpty)
-
-    var composed: [String] = []
-    for phrase in walked {
-      if let node = phrase.node {
-        composed.append(node.currentKeyValue.value)
-      }
-    }
-    print(composed)
-    let correctResult = ["高科技", "公司", "的", "年終", "獎金", "你", "這樣"]
-    print(" - 上述列印結果理應於下面這行一致：")
-    print(correctResult)
-    XCTAssertEqual(composed, correctResult)
-
-    // 測試 DumpDOT
-    compositor.cursorIndex = compositor.length
-    compositor.deleteReadingAtTheRearOfCursor()
-    compositor.deleteReadingAtTheRearOfCursor()
-    compositor.deleteReadingAtTheRearOfCursor()
-    let expectedDumpDOT =
-      "digraph {\ngraph [ rankdir=LR ];\nBOS;\nBOS -> 高;\n高;\n高 -> 科;\n高 -> 科技;\nBOS -> 高科技;\n高科技;\n高科技 -> 工;\n高科技 -> 公司;\n科;\n科 -> 際;\n科 -> 濟公;\n科技;\n科技 -> 工;\n科技 -> 公司;\n際;\n際 -> 工;\n際 -> 公司;\n濟公;\n濟公 -> 斯;\n工;\n工 -> 斯;\n公司;\n公司 -> 的;\n斯;\n斯 -> 的;\n的;\n的 -> 年;\n的 -> 年終;\n年;\n年 -> 中;\n年終;\n年終 -> 獎;\n年終 -> 獎金;\n中;\n中 -> 獎;\n中 -> 獎金;\n獎;\n獎 -> 金;\n獎金;\n獎金 -> EOS;\n金;\n金 -> EOS;\nEOS;\n}\n"
-    XCTAssertEqual(compositor.grid.dumpDOT, expectedDumpDOT)
   }
 
   // MARK: - Test Word Segmentation (SimpleLM)
@@ -259,14 +155,7 @@ final class MegrezTests: XCTestCase {
     compositor.insertReadingAtCursor(reading: "獎")
     compositor.insertReadingAtCursor(reading: "金")
 
-    let walked = Array(compositor.reverseWalk(at: compositor.grid.width, score: 0.0).reversed())
-
-    var segmented: [String] = []
-    for phrase in walked {
-      if let key = phrase.node?.currentKeyValue.key {
-        segmented.append(key)
-      }
-    }
+    let segmented: [String] = compositor.walk().map(\.node.currentPair.key)
     print(segmented)
     let correctResult = ["高科技", "公司", "的", "年終", "獎金"]
     print(" - 上述列印結果理應於下面這行一致：")
@@ -278,8 +167,8 @@ final class MegrezTests: XCTestCase {
 
 // MARK: - 用以測試的語言模型（簡單範本型）
 
-class SimpleLM: Megrez.LanguageModel {
-  var mutDatabase: [String: [Megrez.Unigram]] = [:]
+class SimpleLM: Megrez.LangModel {
+  var database: [String: [Megrez.Unigram]] = [:]
   init(input: String, swapKeyValue: Bool = false) {
     super.init()
     let sstream = input.components(separatedBy: "\n")
@@ -300,12 +189,12 @@ class SimpleLM: Megrez.LanguageModel {
         u.keyValue.value = col1
       }
       u.score = col2
-      mutDatabase[u.keyValue.key, default: []].append(u)
+      database[u.keyValue.key, default: []].append(u)
     }
   }
 
   override func unigramsFor(key: String) -> [Megrez.Unigram] {
-    if let f = mutDatabase[key] {
+    if let f = database[key] {
       return f
     } else {
       return [Megrez.Unigram]().sorted { $0.score > $1.score }
@@ -313,101 +202,101 @@ class SimpleLM: Megrez.LanguageModel {
   }
 
   override func hasUnigramsFor(key: String) -> Bool {
-    mutDatabase.keys.contains(key)
+    database.keys.contains(key)
   }
 }
 
 // MARK: - 用以測試的詞頻數據
 
 private let strSampleData = #"""
-#
-# 下述詞頻資料取自 libTaBE 資料庫 (http://sourceforge.net/projects/libtabe/)
-# (2002 最終版). 該專案於 1999 年由 Pai-Hsiang Hsiao 發起、以 BSD 授權發行。
-#
-ni3 你 -6.000000 // Non-LibTaBE
-zhe4 這 -6.000000 // Non-LibTaBE
-yang4 樣 -6.000000 // Non-LibTaBE
-si1 絲 -9.495858
-si1 思 -9.006414
-si1 私 -99.000000
-si1 斯 -8.091803
-si1 司 -99.000000
-si1 嘶 -13.513987
-si1 撕 -12.259095
-gao1 高 -7.171551
-ke1 顆 -10.574273
-ke1 棵 -11.504072
-ke1 刻 -10.450457
-ke1 科 -7.171052
-ke1 柯 -99.000000
-gao1 膏 -11.928720
-gao1 篙 -13.624335
-gao1 糕 -12.390804
-de5 的 -3.516024
-di2 的 -3.516024
-di4 的 -3.516024
-zhong1 中 -5.809297
-de5 得 -7.427179
-gong1 共 -8.381971
-gong1 供 -8.501463
-ji4 既 -99.000000
-jin1 今 -8.034095
-gong1 紅 -8.858181
-ji4 際 -7.608341
-ji4 季 -99.000000
-jin1 金 -7.290109
-ji4 騎 -10.939895
-zhong1 終 -99.000000
-ji4 記 -99.000000
-ji4 寄 -99.000000
-jin1 斤 -99.000000
-ji4 繼 -9.715317
-ji4 計 -7.926683
-ji4 暨 -8.373022
-zhong1 鐘 -9.877580
-jin1 禁 -10.711079
-gong1 公 -7.877973
-gong1 工 -7.822167
-gong1 攻 -99.000000
-gong1 功 -99.000000
-gong1 宮 -99.000000
-zhong1 鍾 -9.685671
-ji4 繫 -10.425662
-gong1 弓 -99.000000
-gong1 恭 -99.000000
-ji4 劑 -8.888722
-ji4 祭 -10.204425
-jin1 浸 -11.378321
-zhong1 盅 -99.000000
-ji4 忌 -99.000000
-ji4 技 -8.450826
-jin1 筋 -11.074890
-gong1 躬 -99.000000
-ji4 冀 -12.045357
-zhong1 忠 -99.000000
-ji4 妓 -99.000000
-ji4 濟 -9.517568
-ji4 薊 -12.021587
-jin1 巾 -99.000000
-jin1 襟 -12.784206
-nian2 年 -6.086515
-jiang3 講 -9.164384
-jiang3 獎 -8.690941
-jiang3 蔣 -10.127828
-nian2 黏 -11.336864
-nian2 粘 -11.285740
-jiang3 槳 -12.492933
-gong1si1 公司 -6.299461
-ke1ji4 科技 -6.736613
-ji4gong1 濟公 -13.336653
-jiang3jin1 獎金 -10.344678
-nian2zhong1 年終 -11.668947
-nian2zhong1 年中 -11.373044
-gao1ke1ji4 高科技 -9.842421
-zhe4yang4 這樣 -6.000000 // Non-LibTaBE
-ni3zhe4 你這 -9.000000 // Non-LibTaBE
-jiao4 教 -3.676169
-jiao4 較 -3.24869962
-jiao4yu4 教育 -3.32220565
-yu4 育 -3.30192952
-"""#
+  #
+  # 下述詞頻資料取自 libTaBE 資料庫 (http://sourceforge.net/projects/libtabe/)
+  # (2002 最終版). 該專案於 1999 年由 Pai-Hsiang Hsiao 發起、以 BSD 授權發行。
+  #
+  ni3 你 -6.000000 // Non-LibTaBE
+  zhe4 這 -6.000000 // Non-LibTaBE
+  yang4 樣 -6.000000 // Non-LibTaBE
+  si1 絲 -9.495858
+  si1 思 -9.006414
+  si1 私 -99.000000
+  si1 斯 -8.091803
+  si1 司 -99.000000
+  si1 嘶 -13.513987
+  si1 撕 -12.259095
+  gao1 高 -7.171551
+  ke1 顆 -10.574273
+  ke1 棵 -11.504072
+  ke1 刻 -10.450457
+  ke1 科 -7.171052
+  ke1 柯 -99.000000
+  gao1 膏 -11.928720
+  gao1 篙 -13.624335
+  gao1 糕 -12.390804
+  de5 的 -3.516024
+  di2 的 -3.516024
+  di4 的 -3.516024
+  zhong1 中 -5.809297
+  de5 得 -7.427179
+  gong1 共 -8.381971
+  gong1 供 -8.501463
+  ji4 既 -99.000000
+  jin1 今 -8.034095
+  gong1 紅 -8.858181
+  ji4 際 -7.608341
+  ji4 季 -99.000000
+  jin1 金 -7.290109
+  ji4 騎 -10.939895
+  zhong1 終 -99.000000
+  ji4 記 -99.000000
+  ji4 寄 -99.000000
+  jin1 斤 -99.000000
+  ji4 繼 -9.715317
+  ji4 計 -7.926683
+  ji4 暨 -8.373022
+  zhong1 鐘 -9.877580
+  jin1 禁 -10.711079
+  gong1 公 -7.877973
+  gong1 工 -7.822167
+  gong1 攻 -99.000000
+  gong1 功 -99.000000
+  gong1 宮 -99.000000
+  zhong1 鍾 -9.685671
+  ji4 繫 -10.425662
+  gong1 弓 -99.000000
+  gong1 恭 -99.000000
+  ji4 劑 -8.888722
+  ji4 祭 -10.204425
+  jin1 浸 -11.378321
+  zhong1 盅 -99.000000
+  ji4 忌 -99.000000
+  ji4 技 -8.450826
+  jin1 筋 -11.074890
+  gong1 躬 -99.000000
+  ji4 冀 -12.045357
+  zhong1 忠 -99.000000
+  ji4 妓 -99.000000
+  ji4 濟 -9.517568
+  ji4 薊 -12.021587
+  jin1 巾 -99.000000
+  jin1 襟 -12.784206
+  nian2 年 -6.086515
+  jiang3 講 -9.164384
+  jiang3 獎 -8.690941
+  jiang3 蔣 -10.127828
+  nian2 黏 -11.336864
+  nian2 粘 -11.285740
+  jiang3 槳 -12.492933
+  gong1si1 公司 -6.299461
+  ke1ji4 科技 -6.736613
+  ji4gong1 濟公 -13.336653
+  jiang3jin1 獎金 -10.344678
+  nian2zhong1 年終 -11.668947
+  nian2zhong1 年中 -11.373044
+  gao1ke1ji4 高科技 -9.842421
+  zhe4yang4 這樣 -6.000000 // Non-LibTaBE
+  ni3zhe4 你這 -9.000000 // Non-LibTaBE
+  jiao4 教 -3.676169
+  jiao4 較 -3.24869962
+  jiao4yu4 教育 -3.32220565
+  yu4 育 -3.30192952
+  """#

--- a/Tests/MegrezTests/MegrezTests.swift
+++ b/Tests/MegrezTests/MegrezTests.swift
@@ -69,7 +69,7 @@ final class MegrezTests: XCTestCase {
     walk()
     compositor.insertReadingAtCursor(reading: "zhong1")
     walk()
-    compositor.grid.fixNodeSelectedCandidate(location: 7, value: "年終")
+    compositor.fixNodeSelectedCandidate(location: 7, value: "年終")
     walk()
     compositor.insertReadingAtCursor(reading: "jiang3")
     walk()
@@ -116,7 +116,7 @@ final class MegrezTests: XCTestCase {
     compositor.deleteReadingAtTheRearOfCursor()
     let expectedDumpDOT =
       "digraph {\ngraph [ rankdir=LR ];\nBOS;\nBOS -> 高;\n高;\n高 -> 科;\n高 -> 科技;\nBOS -> 高科技;\n高科技;\n高科技 -> 工;\n高科技 -> 公司;\n科;\n科 -> 際;\n科 -> 濟公;\n科技;\n科技 -> 工;\n科技 -> 公司;\n際;\n際 -> 工;\n際 -> 公司;\n濟公;\n濟公 -> 斯;\n工;\n工 -> 斯;\n公司;\n公司 -> 的;\n斯;\n斯 -> 的;\n的;\n的 -> 年;\n的 -> 年終;\n年;\n年 -> 中;\n年終;\n年終 -> 獎;\n年終 -> 獎金;\n中;\n中 -> 獎;\n中 -> 獎金;\n獎;\n獎 -> 金;\n獎金;\n獎金 -> EOS;\n金;\n金 -> EOS;\nEOS;\n}\n"
-    XCTAssertEqual(compositor.grid.dumpDOT, expectedDumpDOT)
+    XCTAssertEqual(compositor.dumpDOT, expectedDumpDOT)
 
     print("========新測試========")
     compositor.clear()
@@ -124,9 +124,9 @@ final class MegrezTests: XCTestCase {
     walk()
     compositor.insertReadingAtCursor(reading: "yu4")
     walk()
-    compositor.grid.fixNodeSelectedCandidate(location: 0, value: "較")
+    compositor.fixNodeSelectedCandidate(location: 0, value: "較")
     walk()
-    compositor.grid.fixNodeSelectedCandidate(location: 2, value: "教育")
+    compositor.fixNodeSelectedCandidate(location: 2, value: "教育")
     walk()
 
     composed = walked.map(\.node.currentPair.value)

--- a/Tests/MegrezTests/MegrezTests.swift
+++ b/Tests/MegrezTests/MegrezTests.swift
@@ -23,280 +23,446 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+import Cocoa
 import XCTest
 
 @testable import Megrez
 
 final class MegrezTests: XCTestCase {
-  // MARK: - Input Test (SimpleLM)
+  func testSpanUnitInternalAbilities() throws {
+    let langModel = SimpleLM(input: strSampleData)
+    var span = Megrez.SpanUnit()
+    let n1 = Megrez.Node(key: "gao", unigrams: langModel.unigramsFor(key: "gao1"))
+    let n3 = Megrez.Node(key: "gao1ke1ji4", unigrams: langModel.unigramsFor(key: "gao1ke1ji4"))
+    XCTAssertEqual(span.maxLength, 0)
+    span.insert(node: n1, length: 1)
+    XCTAssertEqual(span.maxLength, 1)
+    span.insert(node: n3, length: 3)
+    XCTAssertEqual(span.maxLength, 3)
+    XCTAssertEqual(span.nodeOf(length: 1), n1)
+    XCTAssertEqual(span.nodeOf(length: 2), nil)
+    XCTAssertEqual(span.nodeOf(length: 3), n3)
+    span.clear()
+    XCTAssertEqual(span.maxLength, 0)
+    XCTAssertEqual(span.nodeOf(length: 1), nil)
+    XCTAssertEqual(span.nodeOf(length: 2), nil)
+    XCTAssertEqual(span.nodeOf(length: 3), nil)
 
-  func testInputWithForwardWalk() throws {
-    print("// 開始測試語言文字輸入處理")
-    let lmTestInput = SimpleLM(input: strSampleData)
-    let compositor = Megrez.Compositor(lm: lmTestInput)
-    var walked = [Megrez.NodeAnchor]()
-
-    func walk() {
-      walked = compositor.walk()
-    }
-
-    // 模擬輸入法的行為，每次敲字或選字都重新 walk。
-    compositor.insertReadingAtCursor(reading: "gao1")
-    walk()
-    compositor.insertReadingAtCursor(reading: "ji4")
-    walk()
-    compositor.cursorIndex = 1
-    compositor.insertReadingAtCursor(reading: "ke1")
-    walk()
-    compositor.cursorIndex = 1
-    compositor.deleteReadingToTheFrontOfCursor()
-    walk()
-    compositor.insertReadingAtCursor(reading: "ke1")
-    walk()
-    compositor.cursorIndex = 0
-    compositor.deleteReadingToTheFrontOfCursor()
-    walk()
-    compositor.insertReadingAtCursor(reading: "gao1")
-    walk()
-    compositor.cursorIndex = compositor.length
-    compositor.insertReadingAtCursor(reading: "gong1")
-    walk()
-    compositor.insertReadingAtCursor(reading: "si1")
-    walk()
-    compositor.insertReadingAtCursor(reading: "de5")
-    walk()
-    compositor.insertReadingAtCursor(reading: "nian2")
-    walk()
-    compositor.insertReadingAtCursor(reading: "zhong1")
-    walk()
-    compositor.fixNodeSelectedCandidate(location: 7, value: "年終")
-    walk()
-    compositor.insertReadingAtCursor(reading: "jiang3")
-    walk()
-    compositor.insertReadingAtCursor(reading: "jin1")
-    walk()
-    compositor.insertReadingAtCursor(reading: "ni3")
-    walk()
-    compositor.insertReadingAtCursor(reading: "zhe4")
-    walk()
-    compositor.insertReadingAtCursor(reading: "yang4")
-    walk()
-
-    // 這裡模擬一個輸入法的常見情況：每次敲一個字詞都會 walk，然後你回頭編輯完一些內容之後又會立刻重新 walk。
-    // 如果只在這裡測試第一遍 walk 的話，測試通過了也無法測試之後再次 walk 是否會正常。
-
-    compositor.cursorIndex = 1
-    compositor.deleteReadingToTheFrontOfCursor()
-
-    // 於是咱們 walk 第二遍
-    walk()
-    XCTAssert(!walked.isEmpty)
-
-    // 做好第三遍的準備，這次咱們來一次插入性編輯。
-    // 重點測試這句是否正常，畢竟是在 walked 過的節點內進行插入編輯。
-    compositor.insertReadingAtCursor(reading: "ke1")
-
-    // 於是咱們 walk 第三遍。
-    // 這一遍會直接曝露「上述修改是否有對 compositor 造成了破壞性的損失」，
-    // 所以很重要。
-    walk()
-    XCTAssert(!walked.isEmpty)
-
-    var composed: [String] = walked.map(\.node.currentPair.value)
-    print(composed)
-    let correctResult = ["高科技", "公司", "的", "年終", "獎金", "你", "這樣"]
-    print(" - 上述列印結果理應於下面這行一致：")
-    print(correctResult)
-    XCTAssertEqual(composed, correctResult)
-
-    // 測試 DumpDOT
-    compositor.cursorIndex = compositor.length
-    compositor.deleteReadingAtTheRearOfCursor()
-    compositor.deleteReadingAtTheRearOfCursor()
-    compositor.deleteReadingAtTheRearOfCursor()
-    let expectedDumpDOT =
-      "digraph {\ngraph [ rankdir=LR ];\nBOS;\nBOS -> 高;\n高;\n高 -> 科;\n高 -> 科技;\nBOS -> 高科技;\n高科技;\n高科技 -> 工;\n高科技 -> 公司;\n科;\n科 -> 際;\n科 -> 濟公;\n科技;\n科技 -> 工;\n科技 -> 公司;\n際;\n際 -> 工;\n際 -> 公司;\n濟公;\n濟公 -> 斯;\n工;\n工 -> 斯;\n公司;\n公司 -> 的;\n斯;\n斯 -> 的;\n的;\n的 -> 年;\n的 -> 年終;\n年;\n年 -> 中;\n年終;\n年終 -> 獎;\n年終 -> 獎金;\n中;\n中 -> 獎;\n中 -> 獎金;\n獎;\n獎 -> 金;\n獎金;\n獎金 -> EOS;\n金;\n金 -> EOS;\nEOS;\n}\n"
-    XCTAssertEqual(compositor.dumpDOT, expectedDumpDOT)
-
-    print("========新測試========")
-    compositor.clear()
-    compositor.insertReadingAtCursor(reading: "jiao4")
-    walk()
-    compositor.insertReadingAtCursor(reading: "yu4")
-    walk()
-    compositor.fixNodeSelectedCandidate(location: 0, value: "較")
-    walk()
-    compositor.fixNodeSelectedCandidate(location: 2, value: "教育")
-    walk()
-
-    composed = walked.map(\.node.currentPair.value)
-    print(composed)
-    let expectedResult = ["教育"]
-    print(" - 上述列印結果理應於下面這行一致：")
-    print(expectedResult)
-    XCTAssertEqual(composed, expectedResult)
+    span.insert(node: n1, length: 1)
+    span.insert(node: n3, length: 3)
+    span.dropNodesBeyond(length: 1)
+    XCTAssertEqual(span.maxLength, 1)
+    XCTAssertEqual(span.nodeOf(length: 1), n1)
+    XCTAssertEqual(span.nodeOf(length: 2), nil)
+    XCTAssertEqual(span.nodeOf(length: 3), nil)
+    span.dropNodesBeyond(length: 0)
+    XCTAssertEqual(span.maxLength, 0)
+    XCTAssertEqual(span.nodeOf(length: 1), nil)
   }
 
-  // MARK: - Test Word Segmentation (SimpleLM)
+  func testBasicFeaturesOfCompositor() throws {
+    let compositor = Megrez.Compositor(lm: MockLM())
+    compositor.joinSeparator = ""
+    XCTAssertEqual(compositor.joinSeparator, "")
+    XCTAssertEqual(compositor.cursorIndex, 0)
+    XCTAssertEqual(compositor.length, 0)
+
+    XCTAssertTrue(compositor.insertReading("a"))
+    XCTAssertEqual(compositor.cursorIndex, 1)
+    XCTAssertEqual(compositor.length, 1)
+    XCTAssertEqual(compositor.width, 1)
+    XCTAssertEqual(compositor.spans[0].maxLength, 1)
+    guard let zeroNode = compositor.spans[0].nodeOf(length: 1) else {
+      return
+    }
+    XCTAssertEqual(zeroNode.key, "a")
+
+    XCTAssertTrue(compositor.dropReading(direction: .rear))
+    XCTAssertEqual(compositor.cursorIndex, 0)
+    XCTAssertEqual(compositor.cursorIndex, 0)
+    XCTAssertEqual(compositor.width, 0)
+  }
+
+  func testInvalidOperations() throws {
+    class TestLM: LangModelProtocol {
+      func bigramsForKeys(precedingKey _: String, key _: String) -> [Megrez.Bigram] {
+        .init()
+      }
+
+      func hasUnigramsFor(key: String) -> Bool { key == "foo" }
+      func unigramsFor(key: String) -> [Megrez.Unigram] {
+        key == "foo" ? [.init(keyValue: .init(key: "foo", value: "foo"), score: -1)] : .init()
+      }
+    }
+
+    let compositor = Megrez.Compositor(lm: TestLM())
+    compositor.joinSeparator = ";"
+    XCTAssertFalse(compositor.insertReading("bar"))
+    XCTAssertFalse(compositor.insertReading(""))
+    XCTAssertFalse(compositor.insertReading(""))
+    XCTAssertFalse(compositor.dropReading(direction: .rear))
+    XCTAssertFalse(compositor.dropReading(direction: .front))
+
+    compositor.insertReading("foo")
+    XCTAssertTrue(compositor.dropReading(direction: .rear))
+    XCTAssertEqual(compositor.length, 0)
+    compositor.insertReading("foo")
+    compositor.cursorIndex = 0
+    XCTAssertTrue(compositor.dropReading(direction: .front))
+    XCTAssertEqual(compositor.length, 0)
+  }
+
+  func testDeleteToTheFrontOfCursor() throws {
+    let compositor = Megrez.Compositor(lm: MockLM())
+    compositor.insertReading("a")
+    compositor.cursorIndex = 0
+    XCTAssertEqual(compositor.cursorIndex, 0)
+    XCTAssertEqual(compositor.length, 1)
+    XCTAssertEqual(compositor.width, 1)
+    XCTAssertFalse(compositor.dropReading(direction: .rear))
+    XCTAssertEqual(compositor.cursorIndex, 0)
+    XCTAssertEqual(compositor.length, 1)
+    XCTAssertTrue(compositor.dropReading(direction: .front))
+    XCTAssertEqual(compositor.cursorIndex, 0)
+    XCTAssertEqual(compositor.length, 0)
+    XCTAssertEqual(compositor.width, 0)
+  }
+
+  func testMultipleSpanUnits() throws {
+    let compositor = Megrez.Compositor(lm: MockLM())
+    compositor.joinSeparator = ";"
+    compositor.insertReading("a")
+    compositor.insertReading("b")
+    compositor.insertReading("c")
+    XCTAssertEqual(compositor.cursorIndex, 3)
+    XCTAssertEqual(compositor.length, 3)
+    XCTAssertEqual(compositor.width, 3)
+    XCTAssertEqual(compositor.spans[0].maxLength, 3)
+    XCTAssertEqual(compositor.spans[0].nodeOf(length: 1)?.key, "a")
+    XCTAssertEqual(compositor.spans[0].nodeOf(length: 2)?.key, "a;b")
+    XCTAssertEqual(compositor.spans[0].nodeOf(length: 3)?.key, "a;b;c")
+    XCTAssertEqual(compositor.spans[1].maxLength, 2)
+    XCTAssertEqual(compositor.spans[1].nodeOf(length: 1)?.key, "b")
+    XCTAssertEqual(compositor.spans[1].nodeOf(length: 2)?.key, "b;c")
+    XCTAssertEqual(compositor.spans[2].maxLength, 1)
+    XCTAssertEqual(compositor.spans[2].nodeOf(length: 1)?.key, "c")
+  }
+
+  func testSpanUnitDeletionFromFront() throws {
+    let compositor = Megrez.Compositor(lm: MockLM())
+    compositor.joinSeparator = ";"
+    compositor.insertReading("a")
+    compositor.insertReading("b")
+    compositor.insertReading("c")
+    XCTAssertFalse(compositor.dropReading(direction: .front))
+    XCTAssertTrue(compositor.dropReading(direction: .rear))
+    XCTAssertEqual(compositor.cursorIndex, 2)
+    XCTAssertEqual(compositor.length, 2)
+    XCTAssertEqual(compositor.width, 2)
+    XCTAssertEqual(compositor.spans[0].maxLength, 2)
+    XCTAssertEqual(compositor.spans[0].nodeOf(length: 1)?.key, "a")
+    XCTAssertEqual(compositor.spans[0].nodeOf(length: 2)?.key, "a;b")
+    XCTAssertEqual(compositor.spans[1].maxLength, 1)
+    XCTAssertEqual(compositor.spans[1].nodeOf(length: 1)?.key, "b")
+  }
+
+  func testSpanUnitDeletionFromMiddle() throws {
+    let compositor = Megrez.Compositor(lm: MockLM())
+    compositor.joinSeparator = ";"
+    compositor.insertReading("a")
+    compositor.insertReading("b")
+    compositor.insertReading("c")
+    compositor.cursorIndex = 2
+
+    XCTAssertTrue(compositor.dropReading(direction: .rear))
+    XCTAssertEqual(compositor.cursorIndex, 1)
+    XCTAssertEqual(compositor.length, 2)
+    XCTAssertEqual(compositor.width, 2)
+    XCTAssertEqual(compositor.spans[0].maxLength, 2)
+    XCTAssertEqual(compositor.spans[0].nodeOf(length: 1)?.key, "a")
+    XCTAssertEqual(compositor.spans[0].nodeOf(length: 2)?.key, "a;c")
+    XCTAssertEqual(compositor.spans[1].maxLength, 1)
+    XCTAssertEqual(compositor.spans[1].nodeOf(length: 1)?.key, "c")
+
+    compositor.clear()
+    compositor.insertReading("a")
+    compositor.insertReading("b")
+    compositor.insertReading("c")
+    compositor.cursorIndex = 1
+
+    XCTAssertTrue(compositor.dropReading(direction: .front))
+    XCTAssertEqual(compositor.cursorIndex, 1)
+    XCTAssertEqual(compositor.length, 2)
+    XCTAssertEqual(compositor.width, 2)
+    XCTAssertEqual(compositor.spans[0].maxLength, 2)
+    XCTAssertEqual(compositor.spans[0].nodeOf(length: 1)?.key, "a")
+    XCTAssertEqual(compositor.spans[0].nodeOf(length: 2)?.key, "a;c")
+    XCTAssertEqual(compositor.spans[1].maxLength, 1)
+    XCTAssertEqual(compositor.spans[1].nodeOf(length: 1)?.key, "c")
+  }
+
+  func testSpanUnitDeletionFromRear() throws {
+    let compositor = Megrez.Compositor(lm: MockLM())
+    compositor.joinSeparator = ";"
+    compositor.insertReading("a")
+    compositor.insertReading("b")
+    compositor.insertReading("c")
+    compositor.cursorIndex = 0
+
+    XCTAssertFalse(compositor.dropReading(direction: .rear))
+    XCTAssertTrue(compositor.dropReading(direction: .front))
+    XCTAssertEqual(compositor.cursorIndex, 0)
+    XCTAssertEqual(compositor.length, 2)
+    XCTAssertEqual(compositor.width, 2)
+    XCTAssertEqual(compositor.spans[0].maxLength, 2)
+    XCTAssertEqual(compositor.spans[0].nodeOf(length: 1)?.key, "b")
+    XCTAssertEqual(compositor.spans[0].nodeOf(length: 2)?.key, "b;c")
+    XCTAssertEqual(compositor.spans[1].maxLength, 1)
+    XCTAssertEqual(compositor.spans[1].nodeOf(length: 1)?.key, "c")
+  }
+
+  func testSpanUnitInsertion() throws {
+    let compositor = Megrez.Compositor(lm: MockLM())
+    compositor.joinSeparator = ";"
+    compositor.insertReading("a")
+    compositor.insertReading("b")
+    compositor.insertReading("c")
+    compositor.cursorIndex = 1
+    compositor.insertReading("X")
+
+    XCTAssertEqual(compositor.cursorIndex, 2)
+    XCTAssertEqual(compositor.length, 4)
+    XCTAssertEqual(compositor.width, 4)
+    XCTAssertEqual(compositor.spans[0].maxLength, 4)
+    XCTAssertEqual(compositor.spans[0].nodeOf(length: 1)?.key, "a")
+    XCTAssertEqual(compositor.spans[0].nodeOf(length: 2)?.key, "a;X")
+    XCTAssertEqual(compositor.spans[0].nodeOf(length: 3)?.key, "a;X;b")
+    XCTAssertEqual(compositor.spans[0].nodeOf(length: 4)?.key, "a;X;b;c")
+    XCTAssertEqual(compositor.spans[1].maxLength, 3)
+    XCTAssertEqual(compositor.spans[1].nodeOf(length: 1)?.key, "X")
+    XCTAssertEqual(compositor.spans[1].nodeOf(length: 2)?.key, "X;b")
+    XCTAssertEqual(compositor.spans[1].nodeOf(length: 3)?.key, "X;b;c")
+    XCTAssertEqual(compositor.spans[2].maxLength, 2)
+    XCTAssertEqual(compositor.spans[2].nodeOf(length: 1)?.key, "b")
+    XCTAssertEqual(compositor.spans[2].nodeOf(length: 2)?.key, "b;c")
+    XCTAssertEqual(compositor.spans[3].maxLength, 1)
+    XCTAssertEqual(compositor.spans[3].nodeOf(length: 1)?.key, "c")
+  }
+
+  func testLongGridDeletion() throws {
+    let compositor = Megrez.Compositor(lm: MockLM())
+    compositor.joinSeparator = ""
+    compositor.insertReading("a")
+    compositor.insertReading("b")
+    compositor.insertReading("c")
+    compositor.insertReading("d")
+    compositor.insertReading("e")
+    compositor.insertReading("f")
+    compositor.insertReading("g")
+    compositor.insertReading("h")
+    compositor.insertReading("i")
+    compositor.insertReading("j")
+    compositor.insertReading("k")
+    compositor.insertReading("l")
+    compositor.insertReading("m")
+    compositor.insertReading("n")
+    compositor.cursorIndex = 7
+    XCTAssertTrue(compositor.dropReading(direction: .rear))
+    XCTAssertEqual(compositor.cursorIndex, 6)
+    XCTAssertEqual(compositor.length, 13)
+    XCTAssertEqual(compositor.width, 13)
+    XCTAssertEqual(compositor.spans[0].nodeOf(length: 6)?.key, "abcdef")
+    XCTAssertEqual(compositor.spans[1].nodeOf(length: 6)?.key, "bcdefh")
+    XCTAssertEqual(compositor.spans[1].nodeOf(length: 5)?.key, "bcdef")
+    XCTAssertEqual(compositor.spans[2].nodeOf(length: 6)?.key, "cdefhi")
+    XCTAssertEqual(compositor.spans[2].nodeOf(length: 5)?.key, "cdefh")
+    XCTAssertEqual(compositor.spans[3].nodeOf(length: 6)?.key, "defhij")
+    XCTAssertEqual(compositor.spans[4].nodeOf(length: 6)?.key, "efhijk")
+    XCTAssertEqual(compositor.spans[5].nodeOf(length: 6)?.key, "fhijkl")
+    XCTAssertEqual(compositor.spans[6].nodeOf(length: 6)?.key, "hijklm")
+    XCTAssertEqual(compositor.spans[7].nodeOf(length: 6)?.key, "ijklmn")
+    XCTAssertEqual(compositor.spans[8].nodeOf(length: 5)?.key, "jklmn")
+  }
+
+  func testLongGridInsertion() throws {
+    let compositor = Megrez.Compositor(lm: MockLM())
+    compositor.joinSeparator = ""
+    compositor.insertReading("a")
+    compositor.insertReading("b")
+    compositor.insertReading("c")
+    compositor.insertReading("d")
+    compositor.insertReading("e")
+    compositor.insertReading("f")
+    compositor.insertReading("g")
+    compositor.insertReading("h")
+    compositor.insertReading("i")
+    compositor.insertReading("j")
+    compositor.insertReading("k")
+    compositor.insertReading("l")
+    compositor.insertReading("m")
+    compositor.insertReading("n")
+    compositor.cursorIndex = 7
+    compositor.insertReading("X")
+    XCTAssertEqual(compositor.cursorIndex, 8)
+    XCTAssertEqual(compositor.length, 15)
+    XCTAssertEqual(compositor.width, 15)
+    XCTAssertEqual(compositor.spans[0].nodeOf(length: 6)?.key, "abcdef")
+    XCTAssertEqual(compositor.spans[1].nodeOf(length: 6)?.key, "bcdefg")
+    XCTAssertEqual(compositor.spans[2].nodeOf(length: 6)?.key, "cdefgX")
+    XCTAssertEqual(compositor.spans[3].nodeOf(length: 6)?.key, "defgXh")
+    XCTAssertEqual(compositor.spans[3].nodeOf(length: 5)?.key, "defgX")
+    XCTAssertEqual(compositor.spans[4].nodeOf(length: 6)?.key, "efgXhi")
+    XCTAssertEqual(compositor.spans[4].nodeOf(length: 5)?.key, "efgXh")
+    XCTAssertEqual(compositor.spans[4].nodeOf(length: 4)?.key, "efgX")
+    XCTAssertEqual(compositor.spans[4].nodeOf(length: 3)?.key, "efg")
+    XCTAssertEqual(compositor.spans[5].nodeOf(length: 6)?.key, "fgXhij")
+    XCTAssertEqual(compositor.spans[6].nodeOf(length: 6)?.key, "gXhijk")
+    XCTAssertEqual(compositor.spans[7].nodeOf(length: 6)?.key, "Xhijkl")
+    XCTAssertEqual(compositor.spans[8].nodeOf(length: 6)?.key, "hijklm")
+  }
 
   func testWordSegmentation() throws {
-    print("// 開始測試語句分節處理")
-    let lmTestSegmentation = SimpleLM(input: strSampleData, swapKeyValue: true)
-    let compositor = Megrez.Compositor(lm: lmTestSegmentation, separator: "")
+    let compositor = Megrez.Compositor(lm: SimpleLM(input: strSampleData, swapKeyValue: true))
+    compositor.joinSeparator = ""
+    for i in "高科技公司的年終獎金" {
+      compositor.insertReading(String(i))
+    }
+    XCTAssertEqual(compositor.walk().keys, ["高科技", "公司", "的", "年終", "獎金"])
+  }
 
-    compositor.insertReadingAtCursor(reading: "高")
-    compositor.insertReadingAtCursor(reading: "科")
-    compositor.insertReadingAtCursor(reading: "技")
-    compositor.insertReadingAtCursor(reading: "公")
-    compositor.insertReadingAtCursor(reading: "司")
-    compositor.insertReadingAtCursor(reading: "的")
-    compositor.insertReadingAtCursor(reading: "年")
-    compositor.insertReadingAtCursor(reading: "終")
-    compositor.insertReadingAtCursor(reading: "獎")
-    compositor.insertReadingAtCursor(reading: "金")
+  func testLanguageInput() throws {
+    let compositor = Megrez.Compositor(lm: SimpleLM(input: strSampleData))
+    compositor.joinSeparator = ""
+    compositor.insertReading("gao1")
+    compositor.insertReading("ji4")
+    compositor.cursorIndex = 1
+    compositor.insertReading("ke1")
+    compositor.cursorIndex = 0
+    compositor.dropReading(direction: .front)
+    compositor.insertReading("gao1")
+    compositor.cursorIndex = compositor.length
+    compositor.insertReading("gong1")
+    compositor.insertReading("si1")
+    compositor.insertReading("de5")
+    compositor.insertReading("nian2")
+    compositor.insertReading("zhong1")
+    compositor.insertReading("jiang3")
+    compositor.insertReading("jin1")
+    var result = compositor.walk()
+    XCTAssertEqual(result.values, ["高科技", "公司", "的", "年中", "獎金"])
+    XCTAssertEqual(compositor.length, 10)
+    compositor.cursorIndex = 7
+    compositor.fixNodeSelectedCandidate("年終", at: 7)
+    result = compositor.walk()
+    XCTAssertEqual(result.values, ["高科技", "公司", "的", "年終", "獎金"])
+  }
 
-    let segmented: [String] = compositor.walk().map(\.node.currentPair.key)
-    print(segmented)
-    let correctResult = ["高科技", "公司", "的", "年終", "獎金"]
-    print(" - 上述列印結果理應於下面這行一致：")
-    print(correctResult)
+  func testOverrideOverlappingNodes() throws {
+    let compositor = Megrez.Compositor(lm: SimpleLM(input: strSampleData))
+    compositor.joinSeparator = ""
+    compositor.insertReading("gao1")
+    compositor.insertReading("ke1")
+    compositor.insertReading("ji4")
+    compositor.cursorIndex = 1
+    compositor.fixNodeSelectedCandidate("膏", at: compositor.cursorIndex)
+    var result = compositor.walk()
+    XCTAssertEqual(result.values, ["膏", "科技"])
+    compositor.fixNodeSelectedCandidate("高科技", at: 2)
+    result = compositor.walk()
+    XCTAssertEqual(result.values, ["高科技"])
+    compositor.fixNodeSelectedCandidate("膏", at: 1)
+    result = compositor.walk()
+    XCTAssertEqual(result.values, ["膏", "科技"])
 
-    XCTAssertEqual(segmented, correctResult)
+    compositor.fixNodeSelectedCandidate("柯", at: 2)
+    result = compositor.walk()
+    XCTAssertEqual(result.values, ["膏", "柯", "際"])
+
+    compositor.fixNodeSelectedCandidate("暨", at: 3)
+    result = compositor.walk()
+    XCTAssertEqual(result.values, ["膏", "柯", "暨"])
+
+    compositor.fixNodeSelectedCandidate("高科技", at: 3)
+    result = compositor.walk()
+    XCTAssertEqual(result.values, ["高科技"])
+  }
+
+  func testOverrideReset() throws {
+    let compositor = Megrez.Compositor(
+      lm: SimpleLM(input: strSampleData + "zhong1jiang3 終講 -11.0\n" + "jiang3jin1 槳襟 -11.0\n"))
+    compositor.joinSeparator = ""
+    compositor.insertReading("nian2")
+    compositor.insertReading("zhong1")
+    compositor.insertReading("jiang3")
+    compositor.insertReading("jin1")
+    var result = compositor.walk()
+    XCTAssertEqual(result.values, ["年中", "獎金"])
+
+    compositor.fixNodeSelectedCandidate("終講", at: 2)
+    result = compositor.walk()
+    XCTAssertEqual(result.values, ["年", "終講", "金"])
+
+    compositor.fixNodeSelectedCandidate("槳襟", at: 3)
+    result = compositor.walk()
+    XCTAssertEqual(result.values, ["年中", "槳襟"])
+
+    compositor.fixNodeSelectedCandidate("年終", at: 1)
+    result = compositor.walk()
+    XCTAssertEqual(result.values, ["年終", "槳襟"])
+  }
+
+  func testCandidateDisambiguation() throws {
+    let compositor = Megrez.Compositor(lm: SimpleLM(input: strEmojiSampleData))
+    compositor.joinSeparator = ""
+    compositor.insertReading("gao1")
+    compositor.insertReading("re4")
+    compositor.insertReading("huo3")
+    compositor.insertReading("yan4")
+    compositor.insertReading("wei2")
+    compositor.insertReading("xian3")
+    var result = compositor.walk()
+    XCTAssertEqual(result.values, ["高熱", "火焰", "危險"])
+
+    compositor.fixNodeSelectedCandidatePair(.init(key: "huo3", value: "🔥"), at: 2)
+    result = compositor.walk()
+    XCTAssertEqual(result.values, ["高熱", "🔥", "焰", "危險"])
+
+    compositor.fixNodeSelectedCandidatePair(.init(key: "huo3yan4", value: "🔥"), at: 3)
+    result = compositor.walk()
+    XCTAssertEqual(result.values, ["高熱", "🔥", "危險"])
+  }
+
+  func testStressBenchmark_MachineGun() throws {
+    // 測試結果發現：只敲入完全雷同的某個漢字的話，想保證使用體驗就得讓一個組字區最多塞 20 字。
+    // 但是呢，日常敲字都是在敲人話，不會出現這種情形，所以組字區內塞 40 字都沒問題。
+    // 天權星引擎目前暫時沒有條件引入 Gramambular 2 的繁天頂（Vertex）算法，只能先這樣了。
+    // 竊以為「讓組字區內容無限擴張」是個偽需求，畢竟組字區太長了的話編輯起來也很麻煩。
+    NSLog("// Stress test preparation begins.")
+    let compositor = Megrez.Compositor(lm: SimpleLM(input: strStressData))
+    for _ in 0..<20 {  // 這個測試最多只能塞 20 字，否則會慢死。
+      compositor.insertReading("yi1")
+    }
+    NSLog("// Stress test started.")
+    let startTime = CFAbsoluteTimeGetCurrent()
+    _ = compositor.walk()
+    let timeElapsed = CFAbsoluteTimeGetCurrent() - startTime
+    NSLog("// Stress test elapsed: \(timeElapsed)s.")
+  }
+
+  func testStressBenchmark_SpeakLikeAHuman() throws {
+    // 與前一個測試相同，但這次測試的是正常人講話。可以看到在這種情況下目前的算法還是比較耐操的。
+    NSLog("// Stress test preparation begins.")
+    let compositor = Megrez.Compositor(lm: SimpleLM(input: strSampleData))
+    let testMaterial: [String] = ["gao1", "ke1", "ji4", "gong1", "si1", "de5", "nian2", "zhong1", "jiang3", "jin1"]
+    for _ in 0..<114 {  // 都敲出第一個野獸常數了，再不夠用就不像話了。
+      for neta in testMaterial {
+        compositor.insertReading(neta)
+      }
+    }
+    NSLog("// Stress test started.")
+    let startTime = CFAbsoluteTimeGetCurrent()
+    _ = compositor.walk()
+    let timeElapsed = CFAbsoluteTimeGetCurrent() - startTime
+    NSLog("// Stress test elapsed: \(timeElapsed)s.")
   }
 }
-
-// MARK: - 用以測試的語言模型（簡單範本型）
-
-class SimpleLM: Megrez.LangModel {
-  var database: [String: [Megrez.Unigram]] = [:]
-  init(input: String, swapKeyValue: Bool = false) {
-    super.init()
-    let sstream = input.components(separatedBy: "\n")
-    for line in sstream {
-      if line.isEmpty || line.hasPrefix("#") {
-        continue
-      }
-      let linestream = line.split(separator: " ")
-      let col0 = String(linestream[0])
-      let col1 = String(linestream[1])
-      let col2 = Double(linestream[2]) ?? 0.0
-      var u = Megrez.Unigram(keyValue: Megrez.KeyValuePaired(), score: 0)
-      if swapKeyValue {
-        u.keyValue.key = col1
-        u.keyValue.value = col0
-      } else {
-        u.keyValue.key = col0
-        u.keyValue.value = col1
-      }
-      u.score = col2
-      database[u.keyValue.key, default: []].append(u)
-    }
-  }
-
-  override func unigramsFor(key: String) -> [Megrez.Unigram] {
-    if let f = database[key] {
-      return f
-    } else {
-      return [Megrez.Unigram]().sorted { $0.score > $1.score }
-    }
-  }
-
-  override func hasUnigramsFor(key: String) -> Bool {
-    database.keys.contains(key)
-  }
-}
-
-// MARK: - 用以測試的詞頻數據
-
-private let strSampleData = #"""
-  #
-  # 下述詞頻資料取自 libTaBE 資料庫 (http://sourceforge.net/projects/libtabe/)
-  # (2002 最終版). 該專案於 1999 年由 Pai-Hsiang Hsiao 發起、以 BSD 授權發行。
-  #
-  ni3 你 -6.000000 // Non-LibTaBE
-  zhe4 這 -6.000000 // Non-LibTaBE
-  yang4 樣 -6.000000 // Non-LibTaBE
-  si1 絲 -9.495858
-  si1 思 -9.006414
-  si1 私 -99.000000
-  si1 斯 -8.091803
-  si1 司 -99.000000
-  si1 嘶 -13.513987
-  si1 撕 -12.259095
-  gao1 高 -7.171551
-  ke1 顆 -10.574273
-  ke1 棵 -11.504072
-  ke1 刻 -10.450457
-  ke1 科 -7.171052
-  ke1 柯 -99.000000
-  gao1 膏 -11.928720
-  gao1 篙 -13.624335
-  gao1 糕 -12.390804
-  de5 的 -3.516024
-  di2 的 -3.516024
-  di4 的 -3.516024
-  zhong1 中 -5.809297
-  de5 得 -7.427179
-  gong1 共 -8.381971
-  gong1 供 -8.501463
-  ji4 既 -99.000000
-  jin1 今 -8.034095
-  gong1 紅 -8.858181
-  ji4 際 -7.608341
-  ji4 季 -99.000000
-  jin1 金 -7.290109
-  ji4 騎 -10.939895
-  zhong1 終 -99.000000
-  ji4 記 -99.000000
-  ji4 寄 -99.000000
-  jin1 斤 -99.000000
-  ji4 繼 -9.715317
-  ji4 計 -7.926683
-  ji4 暨 -8.373022
-  zhong1 鐘 -9.877580
-  jin1 禁 -10.711079
-  gong1 公 -7.877973
-  gong1 工 -7.822167
-  gong1 攻 -99.000000
-  gong1 功 -99.000000
-  gong1 宮 -99.000000
-  zhong1 鍾 -9.685671
-  ji4 繫 -10.425662
-  gong1 弓 -99.000000
-  gong1 恭 -99.000000
-  ji4 劑 -8.888722
-  ji4 祭 -10.204425
-  jin1 浸 -11.378321
-  zhong1 盅 -99.000000
-  ji4 忌 -99.000000
-  ji4 技 -8.450826
-  jin1 筋 -11.074890
-  gong1 躬 -99.000000
-  ji4 冀 -12.045357
-  zhong1 忠 -99.000000
-  ji4 妓 -99.000000
-  ji4 濟 -9.517568
-  ji4 薊 -12.021587
-  jin1 巾 -99.000000
-  jin1 襟 -12.784206
-  nian2 年 -6.086515
-  jiang3 講 -9.164384
-  jiang3 獎 -8.690941
-  jiang3 蔣 -10.127828
-  nian2 黏 -11.336864
-  nian2 粘 -11.285740
-  jiang3 槳 -12.492933
-  gong1si1 公司 -6.299461
-  ke1ji4 科技 -6.736613
-  ji4gong1 濟公 -13.336653
-  jiang3jin1 獎金 -10.344678
-  nian2zhong1 年終 -11.668947
-  nian2zhong1 年中 -11.373044
-  gao1ke1ji4 高科技 -9.842421
-  zhe4yang4 這樣 -6.000000 // Non-LibTaBE
-  ni3zhe4 你這 -9.000000 // Non-LibTaBE
-  jiao4 教 -3.676169
-  jiao4 較 -3.24869962
-  jiao4yu4 教育 -3.32220565
-  yu4 育 -3.30192952
-  """#


### PR DESCRIPTION
本次 v1.2.8 維護更新主要修改這幾點：

已經完成的內容：

1. 符號命名體系有所更動，活用 private(set)。
2. 將 Compositor 與 Grid 整合：前者直接繼承後者。
3. 因為實際使用當中 NodeAnchor 的 Node 一定不會是 nil，所以直接去掉了這個變數的 nil 能力。這樣可以（同時在模組內與模組外）節省海量的 guard-let / if-let 判定。
4. 對 walk() 做了簡化：將 reverseWalk() 作為內部處理隱藏起來，且讓對外的 walk() 無須傳入任何參數。
5. 讓 fixNode 手動選字函式的生效範圍更廣，且允許在此過程中僅針對指定讀音來執行手動選字操作。
6. 豐富單元測試的內容。
7. NodeAnchor 及 Node 這兩種型別現可雜湊化。

P.S.: 本次特意有測試是否可以將 NodeAnchor 與 Node 整合在一起。然而這樣一來的話會導致手動選字功能失效，所以只能作罷。NodeAnchor 這個結構型別獨立而生所帶來的唯一便利，恐怕就是為了讓裡面的 Node 對自身的函數操作生效。
