### PR TITLE
1.2.9 // Vertex walker (WIP) and structural optimizations. 

### DIFF
--- a/Sources/Megrez/1_Compositor.swift
+++ b/Sources/Megrez/1_Compositor.swift
@@ -186,7 +186,7 @@ extension Megrez {
 
       var paths = [[NodeAnchor]]()
       let nodes = nodesEndingAt(location: location).stableSorted {
-        $0.scoreForSort > $1.scoreForSort
+        $0.node.score > $1.node.score
       }
 
       guard !nodes.isEmpty else { return .init() }  // 防止下文出現範圍外索引的錯誤
@@ -275,7 +275,7 @@ extension Megrez {
           if hasMatchedNode(location: p, spanLength: q, key: combinedReading) { continue }
           let unigrams: [Unigram] = langModel.unigramsFor(key: combinedReading)
           if unigrams.isEmpty { continue }
-          let n = Node(key: combinedReading, unigrams: unigrams)
+          let n: Node = .init(key: combinedReading, spanLength: q, unigrams: unigrams)
           insertNode(node: n, location: p, spanLength: q)
         }
       }

--- a/Sources/Megrez/1_Compositor.swift
+++ b/Sources/Megrez/1_Compositor.swift
@@ -38,7 +38,12 @@ extension Megrez {
     private var langModel: LangModelProtocol
     /// 允許查詢當前游標位置屬於第幾個幅位座標（從 0 開始算）。
     private(set) var cursorRegionMap: [Int: Int] = .init()
-    private(set) var walkedAnchors: [Megrez.NodeAnchor] = []  // 用以記錄爬過的節錨的陣列
+    /// 用以記錄爬過的節錨的陣列
+    private(set) var walkedAnchors: [NodeAnchor] = []
+    /// 該函式用以更新爬過的節錨的陣列
+    public func updateWalkedAnchors(with nodes: [Node]) {
+      walkedAnchors = nodes.map { Megrez.NodeAnchor(node: $0) }
+    }
 
     /// 公開：多字讀音鍵當中用以分割漢字讀音的記號，預設為空。
     public var joinSeparator: String = "-"
@@ -64,8 +69,9 @@ extension Megrez {
         case currentRegionBorderRear:
           switch direction {
             case .front:
-              if currentRegion > walkedAnchors.count { cursor = readings.count }
-              else { cursor = walkedAnchors[0...currentRegion].map(\.spanLength).reduce(0, +) }
+              cursor =
+                (currentRegion > walkedAnchors.count)
+                ? readings.count : walkedAnchors[0...currentRegion].map(\.spanLength).reduce(0, +)
             case .rear:
               cursor = walkedAnchors[0..<aRegionForward].map(\.spanLength).reduce(0, +)
           }

--- a/Sources/Megrez/1_Compositor.swift
+++ b/Sources/Megrez/1_Compositor.swift
@@ -93,7 +93,7 @@ extension Megrez {
     ///   - separator: 多字讀音鍵當中用以分割漢字讀音的記號，預設為空。
     public init(lm: LangModelProtocol, length: Int = 10, separator: String = "-") {
       langModel = lm
-      super.init(spanLength: abs(length))  // 防呆
+      super.init(spanLengthLimit: abs(length))  // 防呆
       joinSeparator = separator
     }
 

--- a/Sources/Megrez/1_VertexWalker.swift
+++ b/Sources/Megrez/1_VertexWalker.swift
@@ -1,0 +1,220 @@
+// Swiftified by (c) 2022 and onwards The vChewing Project (MIT-NTL License).
+// Rebranded from (c) Lukhnos Liu's C++ library "Gramambular" (MIT License).
+/*
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+1. The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+2. No trademark license is granted to use the trade names, trademarks, service
+marks, or product names of Contributor, except as required to fulfill notice
+requirements above.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+// NOTE: This file is optional. Its internal functions are not enabled yet and need to be fixed.
+
+extension Megrez {
+  /// 一個「有向無環圖的」的頂點單位。
+  ///
+  /// 這是一個可變的數據結構，用於有向無環圖的構建和單源最短路徑的計算。
+  class Vertex {
+    /// 前述頂點。
+    public var prev: Vertex?
+    /// 自身屬下的頂點陣列。
+    public var edges = [Vertex]()
+    /// 該變數用於最短路徑的計算。
+    ///
+    /// 我們實際上是在計算具有最大權重的路徑，因此距離的初始值是負無窮的。
+    /// 如果我們要計算最短的權重/距離，我們會將其初期值設為正無窮。
+    public var distance = -(Double.infinity)
+    /// Used during topological-sort.
+    public var topologicallySorted = false
+    public var node: Node
+    public init(node: Node) {
+      self.node = node
+    }
+
+    /// 卸勁函式。
+    ///
+    /// 「卸勁 (relax)」一詞出自 Cormen 在 2001 年的著作「Introduction to Algorithms」的 585 頁。
+    /// - Parameters:
+    ///   - u: 參照頂點，會在必要時成為 v 的前述頂點。
+    ///   - v: 要影響的頂點。
+    static func relax(u: Vertex, v: inout Vertex) {
+      /// 從 u 到 W 的距離，也就是 v 的權重。
+      let w: Double = v.node.score
+      /// 我們正在計算最大權重：
+      /// 如果 v 目前的距離值小於「u 的距離值＋w（w 是 u 到 W 的距離，也就是 v 的權重）」，
+      /// 我們就更新 v 的距離及其前述頂點。
+      if v.distance < u.distance + w {
+        v.distance = u.distance + w
+        v.prev = u
+      }
+    }
+
+    /// 對持有單個根頂點的有向無環圖進行位相幾何排序（topological
+    /// sort）、且將排序結果以頂點陣列的形式給出。
+    ///
+    /// 這裡使用我們自己的堆棧和狀態定義實現了一個非遞迴版本，
+    /// 這樣我們就不會受到當前線程的堆棧大小的限制。以下是等價的原始算法。
+    /// ```
+    ///  func topologicalSort(Vertex* vertex) {
+    ///    for vertexNode in vertex.edges {
+    ///      if !vertexNode.topologicallySorted {
+    ///        dfs(vertexNode, result)
+    ///      }
+    ///    }
+    ///    v.topologicallySorted = true
+    ///    result.append(v)
+    ///  }
+    /// ```
+    /// 至於遞迴版本則類似於 Cormen 在 2001 年的著作「Introduction to Algorithms」當中的樣子。
+    /// - Parameter root: 根頂點。
+    /// - Returns: 排序結果（頂點陣列）。
+    static func topologicalSort(root: Vertex) -> [Vertex] {
+      var result: [Vertex] = []
+      struct State {
+        var edgeIter: Int
+        var edgeItered: Vertex { vertex.edges[edgeIter] }
+        var vertex: Vertex
+        init(vertex: Vertex) {
+          self.vertex = vertex
+          edgeIter = 0
+        }
+      }
+      var stack: [State] = [.init(vertex: root)]
+
+      while var state = stack.last {
+        if state.edgeIter != state.vertex.edges.count {
+          let nextVertex = state.edgeItered
+          state.edgeIter += 1
+          if !nextVertex.topologicallySorted {
+            stack.append(.init(vertex: nextVertex))
+            continue
+          }
+        }
+        state.vertex.topologicallySorted = true
+        result.append(state.vertex)
+        stack.removeLast()
+      }
+      return result
+    }
+  }
+}
+
+extension Megrez.Compositor {
+  // MARK: - Fast Walker
+
+  public struct WalkResult {
+    var nodes: [Megrez.Node]
+    var vertices: Int
+    var edges: Int
+    var values: [String] {
+      nodes.map(\.currentPair.value)
+    }
+
+    var keys: [String] {
+      nodes.map(\.key)
+    }
+  }
+
+  /// 對已給定的軌格，使用頂點算法，按照給定的位置與條件進行正向爬軌。
+  ///
+  /// ⚠︎ 該方法有已知問題，會無視 fixNodeWithCandidate() 的前置操作效果。
+  /// - Returns: 一個包含有效結果的節錨陣列。
+  @discardableResult public func fastWalk() -> [Megrez.NodeAnchor] {
+    vertexWalk()
+    updateCursorJumpingTables(walkedAnchors)
+    return walkedAnchors
+  }
+
+  /// 找到軌格陣圖內權重最大的路徑。該路徑代表了可被觀測到的最可能的隱藏事件鏈。
+  /// 這裡使用 Cormen 在 2001 年出版的教材當中提出的「有向無環圖的最短路徑」的
+  /// 算法來計算這種路徑。不過，這裡不是要計算距離最短的路徑，而是計算距離最長
+  /// 的路徑（所以要找最大的權重），因為在對數概率下，較大的數值意味著較大的概率。
+  /// 對於 `G = (V, E)`，該算法的運行次數為 `O(|V|+|E|)`，其中 `G` 是一個有向無環圖。
+  /// 這意味著，即使軌格很大，也可以用很少的算力就可以爬軌。
+  /// - Returns: 爬軌結果＋該過程是否順利執行。
+  @discardableResult internal func vertexWalk() -> (WalkResult, Bool) {
+    var result = WalkResult(nodes: .init(), vertices: 0, edges: 0)
+    guard !spans.isEmpty else {
+      updateWalkedAnchors(with: .init())
+      return (result, true)
+    }
+
+    var vertexSpans = [[Megrez.Vertex]]()
+    for _ in spans {
+      vertexSpans.append(.init())
+    }
+
+    for (i, span) in spans.enumerated() {
+      for j in 1...span.maxLength {
+        if let p = span.nodeOf(length: j) {
+          vertexSpans[i].append(.init(node: p))
+          result.vertices += 1
+        }
+      }
+    }
+
+    let terminal = Megrez.Vertex(node: .init(key: "_TERMINAL_", spanLength: 0, unigrams: .init()))
+
+    for (i, vertexSpan) in vertexSpans.enumerated() {
+      for vertex in vertexSpan {
+        let nextVertexPosition = i + vertex.node.spanLength
+        if nextVertexPosition == vertexSpans.count {
+          vertex.edges.append(terminal)
+          continue
+        }
+        for nextVertex in vertexSpans[nextVertexPosition] {
+          vertex.edges.append(nextVertex)
+          result.edges += 1
+        }
+      }
+    }
+
+    let root = Megrez.Vertex(node: .init(key: "_ROOT_", spanLength: 0, unigrams: .init()))
+    root.distance = 0
+    root.edges.append(contentsOf: vertexSpans[0])
+
+    var ordered: [Megrez.Vertex] = Megrez.Vertex.topologicalSort(root: root)
+
+    for (j, neta) in ordered.enumerated() {
+      for (k, _) in ordered[j].edges.enumerated() {
+        Megrez.Vertex.relax(u: ordered[j], v: &ordered[j].edges[k])
+      }
+      ordered[j] = neta
+    }
+
+    var walked = [Megrez.Node]()
+    var totalReadingLength = 0
+    while totalReadingLength < readings.count + 2, let lastEdge = ordered.reversed()[totalReadingLength].edges.last {
+      if let vertexPrev = lastEdge.prev, !vertexPrev.node.currentPair.value.isEmpty {
+        walked.append(vertexPrev.node)
+      } else if !lastEdge.node.currentPair.value.isEmpty {
+        walked.append(lastEdge.node)
+      }
+      let oldTotalReadingLength = totalReadingLength
+      totalReadingLength += lastEdge.node.spanLength
+      if oldTotalReadingLength == totalReadingLength { break }
+    }
+
+    guard totalReadingLength == readings.count else {
+      print("!!! ERROR A: readingLength: \(totalReadingLength), readingCount: \(readings.count)")
+      updateWalkedAnchors(with: .init())
+      return (result, false)
+    }
+
+    result.nodes = Array(walked)
+    updateWalkedAnchors(with: result.nodes)
+    return (result, true)
+  }
+}

--- a/Sources/Megrez/2_Grid.swift
+++ b/Sources/Megrez/2_Grid.swift
@@ -114,14 +114,7 @@ extension Megrez {
       let span = spans[location]
       for i in 1...maxBuildSpanLength {
         if let np = span.nodeOf(length: i) {
-          np.spanLength = i
-          results.append(
-            .init(
-              node: np,
-              location: location,
-              spanLength: i
-            )
-          )
+          results.append(.init(node: np))
         }
       }
       return results  // 已證實不會有空節點產生。
@@ -138,14 +131,7 @@ extension Megrez {
         let span = spans[i]
         if i + span.maxLength < location { continue }
         if let np = span.nodeOf(length: location - i) {
-          np.spanLength = location - i
-          results.append(
-            .init(
-              node: np,
-              location: i,
-              spanLength: location - i
-            )
-          )
+          results.append(.init(node: np))
         }
       }
       return results  // 已證實不會有空節點產生。
@@ -164,14 +150,7 @@ extension Megrez {
         for j in 1...span.maxLength {
           if i + j < location { continue }
           if let np = span.nodeOf(length: j) {
-            np.spanLength = location - i
-            results.append(
-              .init(
-                node: np,
-                location: i,
-                spanLength: location - i
-              )
-            )
+            results.append(.init(node: np))
           }
         }
       }

--- a/Sources/Megrez/2_Grid.swift
+++ b/Sources/Megrez/2_Grid.swift
@@ -41,8 +41,8 @@ extension Megrez {
     public var isEmpty: Bool { spans.isEmpty }
 
     /// 初期化轨格。
-    public init(spanLength: Int = 10) {
-      maxBuildSpanLength = spanLength
+    public init(spanLengthLimit: Int = 10) {
+      maxBuildSpanLength = spanLengthLimit
       spans = [Megrez.SpanUnit]()
     }
 
@@ -114,6 +114,7 @@ extension Megrez {
       let span = spans[location]
       for i in 1...maxBuildSpanLength {
         if let np = span.nodeOf(length: i) {
+          np.spanLength = i
           results.append(
             .init(
               node: np,
@@ -137,6 +138,7 @@ extension Megrez {
         let span = spans[i]
         if i + span.maxLength < location { continue }
         if let np = span.nodeOf(length: location - i) {
+          np.spanLength = location - i
           results.append(
             .init(
               node: np,
@@ -162,6 +164,7 @@ extension Megrez {
         for j in 1...span.maxLength {
           if i + j < location { continue }
           if let np = span.nodeOf(length: j) {
+            np.spanLength = location - i
             results.append(
               .init(
                 node: np,

--- a/Sources/Megrez/3_NodeAnchor.swift
+++ b/Sources/Megrez/3_NodeAnchor.swift
@@ -30,28 +30,39 @@ extension Megrez {
     public var isEmpty: Bool { node.key.isEmpty }
     /// 節點。一個節锚內不一定有節點。
     public var node: Node = .init()
-    /// 節锚所在的位置。
-    public var location: Int = 0
     /// 指定的幅位長度。
-    public var spanLength: Int = 0 { didSet { node.spanLength = spanLength } }
+    public var spanLength: Int { node.spanLength }
+    /// 獲取用來比較的權重。
+    public var scoreForSort: Double { node.score }
     /// 累計權重。
     public var mass: Double = 0.0
+    /// 單元圖陣列。
+    public var unigrams: [Unigram] { node.unigrams }
+    /// 雙元圖陣列。
+    public var bigrams: [Bigram] { node.bigrams }
+    /// 鍵。
+    public var key: String { node.key }
     /// 索引鍵的長度。
     public var keyLength: Int {
       isEmpty ? node.key.count : 0
     }
 
+    /// 初期化一個節錨。
+    public init(node: Node = .init(), mass: Double? = nil) {
+      self.node = node
+      self.mass = mass ?? self.node.score
+    }
+
+    /// 將該節錨雜湊化。
     public func hash(into hasher: inout Hasher) {
       hasher.combine(node)
-      hasher.combine(location)
-      hasher.combine(spanLength)
       hasher.combine(mass)
     }
 
     /// 將當前節锚列印成一個字串。
     public var description: String {
       var stream = ""
-      stream += "{@(" + String(location) + "," + String(spanLength) + "),"
+      stream += "{@(" + String(spanLength) + "),"
       if node.key.isEmpty {
         stream += node.description
       } else {
@@ -59,11 +70,6 @@ extension Megrez {
       }
       stream += "}"
       return stream
-    }
-
-    /// 獲取用來比較的權重。
-    public var scoreForSort: Double {
-      isEmpty ? node.score : 0
     }
   }
 }

--- a/Sources/Megrez/3_NodeAnchor.swift
+++ b/Sources/Megrez/3_NodeAnchor.swift
@@ -33,7 +33,7 @@ extension Megrez {
     /// 節锚所在的位置。
     public var location: Int = 0
     /// 指定的幅位長度。
-    public var spanLength: Int = 0
+    public var spanLength: Int = 0 { didSet { node.spanLength = spanLength } }
     /// 累計權重。
     public var mass: Double = 0.0
     /// 索引鍵的長度。

--- a/Sources/Megrez/3_Span.swift
+++ b/Sources/Megrez/3_Span.swift
@@ -43,7 +43,6 @@ extension Megrez {
     ///   - length: 給定的節點長度。
     mutating func insert(node: Node, length: Int) {
       let length = abs(length)  // 防呆
-      node.spanLength = length
       lengthNodeMap[length] = node
       maxLength = max(maxLength, length)
     }

--- a/Sources/Megrez/3_Span.swift
+++ b/Sources/Megrez/3_Span.swift
@@ -43,6 +43,7 @@ extension Megrez {
     ///   - length: 給定的節點長度。
     mutating func insert(node: Node, length: Int) {
       let length = abs(length)  // 防呆
+      node.spanLength = length
       lengthNodeMap[length] = node
       maxLength = max(maxLength, length)
     }

--- a/Sources/Megrez/4_Node.swift
+++ b/Sources/Megrez/4_Node.swift
@@ -30,7 +30,7 @@ extension Megrez {
       lhs.key == rhs.key && lhs.score == rhs.score && lhs.unigrams == rhs.unigrams && lhs.bigrams == rhs.bigrams
         && lhs.candidates == rhs.candidates && lhs.valueUnigramIndexMap == rhs.valueUnigramIndexMap
         && lhs.precedingBigramMap == rhs.precedingBigramMap && lhs.isCandidateFixed == rhs.isCandidateFixed
-        && lhs.selectedUnigramIndex == rhs.selectedUnigramIndex
+        && lhs.selectedUnigramIndex == rhs.selectedUnigramIndex && lhs.spanLength == rhs.spanLength
     }
 
     public func hash(into hasher: inout Hasher) {
@@ -38,6 +38,7 @@ extension Megrez {
       hasher.combine(score)
       hasher.combine(unigrams)
       hasher.combine(bigrams)
+      hasher.combine(spanLength)
       hasher.combine(candidates)
       hasher.combine(valueUnigramIndexMap)
       hasher.combine(precedingBigramMap)
@@ -53,6 +54,8 @@ extension Megrez {
     private var unigrams: [Unigram]
     /// 雙元圖陣列。
     private var bigrams: [Bigram]
+    /// 指定的幅位長度。
+    public var spanLength: Int = 0
     /// 候選字詞陣列，以鍵值陣列的形式存在。
     private(set) var candidates: [KeyValuePaired] = []
     /// 專門「用單元圖資料值來調查索引值」的辭典。
@@ -83,10 +86,11 @@ extension Megrez {
     ///   - key: 索引鍵。
     ///   - unigrams: 單元圖陣列。
     ///   - bigrams: 雙元圖陣列（非必填）。
-    public init(key: String = "", unigrams: [Megrez.Unigram] = [], bigrams: [Megrez.Bigram] = []) {
+    public init(key: String = "", spanLength: Int = 0, unigrams: [Megrez.Unigram] = [], bigrams: [Megrez.Bigram] = []) {
       self.key = key
       self.unigrams = unigrams
       self.bigrams = bigrams
+      self.spanLength = spanLength
 
       self.unigrams.sort {
         $0.score > $1.score

--- a/Sources/Megrez/4_Node.swift
+++ b/Sources/Megrez/4_Node.swift
@@ -51,9 +51,9 @@ extension Megrez {
     /// 當前節點的當前被選中的候選字詞「在該節點內的」目前的權重。
     private(set) var score: Double = 0
     /// 單元圖陣列。
-    private var unigrams: [Unigram]
+    private(set) var unigrams: [Unigram]
     /// 雙元圖陣列。
-    private var bigrams: [Bigram]
+    private(set) var bigrams: [Bigram]
     /// 指定的幅位長度。
     public var spanLength: Int = 0
     /// 候選字詞陣列，以鍵值陣列的形式存在。


### PR DESCRIPTION
- NodeAnchor 結構進一步縮減，相關參數除了 mass 以外全部下放給 node。這樣一來，初期化一個 NodeAnchor 只需要 node 本體即可、且可以在想指定 mass 的時候指定之。至於 mass 這個參數不能下放給 node，是有原因的：一旦下放了，會影響選字、使得多字組成的詞必須得有相當高的權重數值才會被 walk() 自動選中。
- 嘗試引入基於頂點算法的爬軌函式 fastWalk()。相關檔案集中在「1_VertexWalker.swift」內。單元測試內有少數內容用來測試該函式的基礎功能。然而，這個函式的引入方法有些問題，導致其無法始終反應手動選字結果。於是，這個函式目前屬於雪藏狀態。