### PR TITLE
Allow resynchronizing unigram data in update().

### DIFF
--- a/Sources/Megrez/4_Span.swift
+++ b/Sources/Megrez/4_Span.swift
@@ -5,15 +5,15 @@
 
 extension Megrez.Compositor {
   /// 幅位乃指一組共享起點的節點。
-  public struct Span {
-    private var nodes: [Node?] = []
+  public class Span {
+    public var nodes: [Node?] = []
     public private(set) var maxLength = 0
     private var maxSpanLength: Int { Megrez.Compositor.maxSpanLength }
     public init() {
       clear()
     }
 
-    public mutating func clear() {
+    public func clear() {
       nodes.removeAll()
       for _ in 0..<maxSpanLength {
         nodes.append(nil)
@@ -24,7 +24,7 @@ extension Megrez.Compositor {
     /// 往該幅位塞入一個節點。
     /// - Parameter node: 要塞入的節點。
     /// - Returns: 該操作是否成功執行。
-    @discardableResult public mutating func append(node: Node) -> Bool {
+    @discardableResult public func append(node: Node) -> Bool {
       guard (1...maxSpanLength).contains(node.spanLength) else {
         return false
       }
@@ -36,7 +36,7 @@ extension Megrez.Compositor {
     /// 丟掉任何不小於給定幅位長度的節點。
     /// - Parameter length: 給定的幅位長度。
     /// - Returns: 該操作是否成功執行。
-    @discardableResult public mutating func dropNodesOfOrBeyond(length: Int) -> Bool {
+    @discardableResult public func dropNodesOfOrBeyond(length: Int) -> Bool {
       guard (1...maxSpanLength).contains(length) else {
         return false
       }
@@ -66,7 +66,7 @@ extension Megrez.Compositor {
   /// 找出所有與該位置重疊的節點。其返回值為一個節錨陣列（包含節點、以及其起始位置）。
   /// - Parameter location: 游標位置。
   /// - Returns: 一個包含所有與該位置重疊的節點的陣列。
-  func fetchOverlappingNodes(at location: Int) -> [NodeAnchor] {
+  internal func fetchOverlappingNodes(at location: Int) -> [NodeAnchor] {
     var results = [NodeAnchor]()
     guard !spans.isEmpty, location < spans.count else { return results }
 

--- a/Sources/Megrez/6_Node.swift
+++ b/Sources/Megrez/6_Node.swift
@@ -39,7 +39,7 @@ extension Megrez.Compositor {
     public private(set) var spanLength: Int
     public private(set) var unigrams: [Megrez.Unigram]
     public private(set) var currentUnigramIndex: Int = 0 {
-      didSet { currentUnigramIndex = min(max(0, currentUnigramIndex), unigrams.count - 1) }
+      didSet { currentUnigramIndex = max(min(unigrams.count - 1, currentUnigramIndex), 0) }
     }
 
     public var currentPair: Megrez.Compositor.KeyValuePaired { .init(key: key, value: value) }
@@ -51,6 +51,18 @@ extension Megrez.Compositor {
       hasher.combine(currentUnigramIndex)
       hasher.combine(spanLength)
       hasher.combine(overrideType)
+    }
+
+    /// 置換掉該節點內的單元圖陣列資料。
+    /// 如果此時影響到了 currentUnigramIndex 所指的內容的話，則將其重設為 0。
+    /// - Parameter source: 新的單元圖陣列資料，必須不能為空（否則必定崩潰）。
+    public func resetUnigrams(using source: [Megrez.Unigram]) {
+      let oldCurrentValue = unigrams[currentUnigramIndex].value
+      unigrams = source
+      // if unigrams.isEmpty { unigrams.append(.init(value: key, score: -114.514)) }  // 保險，請按需啟用。
+      currentUnigramIndex = max(min(unigrams.count - 1, currentUnigramIndex), 0)
+      let newCurrentValue = unigrams[currentUnigramIndex].value
+      if oldCurrentValue != newCurrentValue { currentUnigramIndex = 0 }
     }
 
     public private(set) var overrideType: Node.OverrideType

--- a/Tests/MegrezTests/LMDataForTests.swift
+++ b/Tests/MegrezTests/LMDataForTests.swift
@@ -36,6 +36,13 @@ class SimpleLM: LangModelProtocol {
   func hasUnigramsFor(key: String) -> Bool {
     mutDatabase.keys.contains(key)
   }
+
+  func trim(key: String, value: String) {
+    guard var arr = mutDatabase[key] else { return }
+    arr = arr.compactMap { $0.value == value ? nil : $0 }
+    guard !arr.isEmpty else { return }
+    mutDatabase[key] = arr
+  }
 }
 
 class MockLM: LangModelProtocol {

--- a/Tests/MegrezTests/MegrezTests.swift
+++ b/Tests/MegrezTests/MegrezTests.swift
@@ -11,7 +11,7 @@ import XCTest
 final class MegrezTests: XCTestCase {
   func testSpan() throws {
     let langModel = SimpleLM(input: strSampleData)
-    var span = Megrez.Compositor.Span()
+    let span = Megrez.Compositor.Span()
     let n1 = Megrez.Compositor.Node(keyArray: ["gao1"], spanLength: 1, unigrams: langModel.unigramsFor(key: "gao1"))
     let n3 = Megrez.Compositor.Node(
       keyArray: ["gao1ke1ji4"], spanLength: 3, unigrams: langModel.unigramsFor(key: "gao1ke1ji4")
@@ -517,5 +517,22 @@ final class MegrezTests: XCTestCase {
     XCTAssertTrue(compositor.overrideCandidate(.init(key: "huo3yan4", value: "🔥"), at: location))
     result = compositor.walk().0
     XCTAssertEqual(result.values, ["高熱", "🔥", "危險"])
+  }
+
+  func testCompositor_updateUnigramData() throws {
+    let theLM = SimpleLM(input: strSampleData)
+    var compositor = Megrez.Compositor(with: theLM)
+    compositor.separator = ""
+    compositor.insertKey("nian2")
+    compositor.insertKey("zhong1")
+    compositor.insertKey("jiang3")
+    compositor.insertKey("jin1")
+    let oldResult = compositor.walk().0.values.joined()
+    print(oldResult)
+    theLM.trim(key: "nian2zhong1", value: "年中")
+    compositor.update(updateExisting: true)
+    let newResult = compositor.walk().0.values.joined()
+    print(newResult)
+    XCTAssertEqual([oldResult, newResult], ["年中獎金", "年終獎金"])
   }
 }


### PR DESCRIPTION
支援「允許更新組字區內所有節幅內的所有節點內的單元圖陣列資料為最新的資料」這一全新特性、以實現上述產品體驗。
  - 為了防止組字引擎崩潰，當語言模組引擎不再針對某些索引鍵提供此前提供過的結果的時候：
    1. 如果該節點的索引鍵陣列只有一個讀音的話，則該節點會被放置處理。
    2. 如果該節點的索引鍵陣列有多個讀音的話，則該節點會被移除。