### PR TITLE
Add a safety check in Compositor.update().

### DIFF
--- a/Sources/Megrez/1_Compositor.swift
+++ b/Sources/Megrez/1_Compositor.swift
@@ -294,7 +294,7 @@ extension Megrez.Compositor {
         guard position + theLength <= keys.count, position >= 0 else { return }
         let joinedKeyArray = keys[position ..< (position + theLength)].map(\.description)
 
-        if let theNode = spans[position][theLength] {
+        if (0 ..< spans.count).contains(position), let theNode = spans[position][theLength] {
           if !updateExisting { return }
           let unigrams = langModel.unigramsFor(keyArray: joinedKeyArray)
           // 自動銷毀無效的節點。


### PR DESCRIPTION
This stops an array-out-of-bounds error.